### PR TITLE
Remove duplicated tables when printing references

### DIFF
--- a/src/Methods.cs
+++ b/src/Methods.cs
@@ -109,15 +109,12 @@ namespace NugetUtility
             foreach (var item in projects)
             {
                 IEnumerable<string> references = this.GetProjectReferences(item);
+                var currentProjectLicenses = await this.GetNugetInformationAsync(item, references);
+                licenses.Add(currentProjectLicenses);
 
-                if (uniqueList)
+                if (!uniqueList)
                 {
-                    licenses.Add(await this.GetNugetInformationAsync(item, references));
-                }
-                else
-                {
-                    licenses.Add(await this.GetNugetInformationAsync(item, references));
-                    PrintLicenses(licenses);
+                    PrintLicenses(currentProjectLicenses);
                 }
 
                 result = true;
@@ -131,18 +128,15 @@ namespace NugetUtility
             return result;
         }
 
-        public void PrintLicenses(List<Dictionary<string, Package>> licenses)
+        public void PrintLicenses(Dictionary<string, Package> licenses)
         {
             if (licenses.Any())
             {
                 Console.WriteLine(Environment.NewLine + "References:");
+                Console.WriteLine(licenses.ToStringTable(new[] { "Reference", "Licence", "Version", "LicenceType" },
+                                                        a => a.Value.Metadata.Id ?? "---", a => a.Value.Metadata.LicenseUrl ?? "---",
+                                                        a => a.Value.Metadata.Version ?? "---", a => (a.Value.Metadata.License != null ? a.Value.Metadata.License.Text : "---")));
 
-                foreach (var license in licenses)
-                {
-                    Console.WriteLine(license.ToStringTable(new[] {"Reference", "Licence", "Version", "LicenceType"},
-                                                            a => a.Value.Metadata.Id ?? "---", a => a.Value.Metadata.LicenseUrl ?? "---",
-                                                            a => a.Value.Metadata.Version ?? "---", a => (a.Value.Metadata.License != null ? a.Value.Metadata.License.Text : "---")));
-                }
             }
         }
 


### PR DESCRIPTION
Currently if t here are more projects in directory, for each project references of previous projects will be reprinted. This pull requests fixes that, it only displays references of current project.