### PR TITLE
added ability to validate mapped library info

### DIFF
--- a/src/Model/IValidationResult.cs
+++ b/src/Model/IValidationResult.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace NugetUtility
+{
+    public interface IValidationResult<T>
+    {
+        bool IsValid { get; }
+        IReadOnlyCollection<T> InvalidPackages { get; }
+    }
+}

--- a/src/Model/ValidationResult.cs
+++ b/src/Model/ValidationResult.cs
@@ -2,10 +2,10 @@
 
 namespace NugetUtility
 {
-    public class ValidationResult
+    public class ValidationResult<T> : IValidationResult<T>
     {
         public bool IsValid { get; set; } = false;
 
-        public IReadOnlyCollection<KeyValuePair<string, Package>> InvalidPackages { get; set; } = new List<KeyValuePair<string, Package>>();
+        public IReadOnlyCollection<T> InvalidPackages { get; set; } = new List<T>();
     }
 }

--- a/src/NugetUtility.csproj
+++ b/src/NugetUtility.csproj
@@ -9,7 +9,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageId>dotnet-project-licenses</PackageId>
     <ToolCommandName>dotnet-project-licenses</ToolCommandName>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <Authors>Tom Chavakis</Authors>
     <Company>-</Company>
     <Title>.NET Core Tool to print a list of the licenses of a projects</Title>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -27,8 +27,8 @@ namespace NugetUtility
 
             Methods methods = new Methods(options);
             var projectsWithPackages = await methods.GetPackages();
-            HandleInvalidLicenses(methods, projectsWithPackages, options.AllowedLicenseType);
             var mappedLibraryInfo = methods.MapPackagesToLibraryInfo(projectsWithPackages);
+            HandleInvalidLicenses(methods, mappedLibraryInfo, options.AllowedLicenseType);
 
             if (options.ExportLicenseTexts)
             {
@@ -54,13 +54,13 @@ namespace NugetUtility
             return 0;
         }
 
-        private static void HandleInvalidLicenses(Methods methods, Dictionary<string, PackageList> projectsWithPackages, ICollection<string> allowedLicenseType)
+        private static void HandleInvalidLicenses(Methods methods, List<LibraryInfo> libraries, ICollection<string> allowedLicenseType)
         {
-            var invalidPackages = methods.ValidateLicenses(projectsWithPackages);
+            var invalidPackages = methods.ValidateLicenses(libraries);
 
             if (!invalidPackages.IsValid)
             {
-                throw new InvalidLicensesException(invalidPackages, allowedLicenseType);
+                throw new InvalidLicensesException<LibraryInfo>(invalidPackages, allowedLicenseType);
             }
         }
     }

--- a/tests/NugetUtility.Tests/InvalidLicenseTests.cs
+++ b/tests/NugetUtility.Tests/InvalidLicenseTests.cs
@@ -15,7 +15,7 @@ namespace NugetUtility.Tests
         [Test]
         public void Should_Format_Exceptions_On_NewLines_With_Allowed_Header(bool hasAllowed)
         {
-            var result = new ValidationResult
+            var result = new ValidationResult<KeyValuePair<string,Package>>
             {
                 IsValid = false,
                 InvalidPackages = new List<KeyValuePair<string, Package>>
@@ -25,7 +25,7 @@ namespace NugetUtility.Tests
                     new KeyValuePair<string, Package>(@"c:\some\project.csproj",new Package{ Metadata = new Metadata {  Id = "BadLicense3", Version = "0.1.0"} }),
                 }
             };
-            var exception = new InvalidLicensesException(result, !hasAllowed ? null : new List<string> { "MIT" });
+            var exception = new InvalidLicensesException<KeyValuePair<string,Package>>(result, !hasAllowed ? null : new List<string> { "MIT" });
 
             exception.Should().NotBeNull();
             exception.Message.Split(Environment.NewLine)

--- a/tests/NugetUtility.Tests/ProgramTests.cs
+++ b/tests/NugetUtility.Tests/ProgramTests.cs
@@ -35,7 +35,7 @@ namespace NugetUtility.Tests
         {
             Func<Task> act = async () => await Program.Main(args.Split(' '));
 
-            await act.Should().ThrowExactlyAsync<InvalidLicensesException>();
+            await act.Should().ThrowExactlyAsync<InvalidLicensesException<LibraryInfo>>();
         }
 
         [Test]


### PR DESCRIPTION
We needed to do validation against the mapped information in another project, so I added it but also left the old way.