### PR TITLE
When a package cannot be found on nuget.org - add dummy license specification.

### DIFF
--- a/src/LicenseToUrlMappings.cs
+++ b/src/LicenseToUrlMappings.cs
@@ -35,7 +35,12 @@ namespace NugetUtility
 
             public int GetHashCode([DisallowNull] string obj) => GetProtocolLessUrl(obj).ToLower().GetHashCode();
 
-            private static string GetProtocolLessUrl(string url) => url.Substring(url.IndexOf(':'));
+            private static string GetProtocolLessUrl(string url)
+            {
+                if (string.IsNullOrEmpty(url)) return "";
+                if (!url.Contains(":")) return "";
+                return url.Substring(url.IndexOf(':'));
+            }
         }
 
         public static LicenseToUrlMappings Default { get; } = new LicenseToUrlMappings

--- a/src/Methods.cs
+++ b/src/Methods.cs
@@ -97,6 +97,10 @@ namespace NugetUtility
                                 _requestCache[lookupKey] = fallbackResult;
                                 await HandleLicensing(fallbackResult);
                             }
+                            else
+                            {
+                                licenses.Add(packageWithVersion, new Package { Metadata = new Metadata { Version = versionNumber, Id = packageId } });
+                            }
 
                             continue;
                         }


### PR DESCRIPTION
This leads to the following:
- Validation will fail for packages that are not found
- If validation is skipped, they properly appear in the list of used packages