### PR TITLE
Create output directory if it does not yet exist

### DIFF
--- a/src/Methods.cs
+++ b/src/Methods.cs
@@ -540,9 +540,15 @@ namespace NugetUtility
 
         private string GetOutputDirectory()
         {
-            return string.IsNullOrWhiteSpace(_packageOptions.OutputFileName)
+            var outputDirectory = string.IsNullOrWhiteSpace(_packageOptions.OutputFileName)
                 ? Environment.CurrentDirectory
                 : Path.GetDirectoryName(_packageOptions.OutputFileName);
+
+            if (!Directory.Exists(outputDirectory))
+            {
+                Directory.CreateDirectory(outputDirectory);
+            }
+            return outputDirectory;
         }
 
         /// <summary>


### PR DESCRIPTION
When the Folder to which the output files should be put to does not exist - create it.