### PR TITLE
Handle PackageReference::Version also as separate element

### DIFF
--- a/src/Methods.cs
+++ b/src/Methods.cs
@@ -593,9 +593,24 @@ namespace NugetUtility
             // Uses an XPath instead of direct navigation (using Elements("…")) as the project file may use xml namespaces
             return projDefinition
                          ?.XPathSelectElements("/*[local-name()='Project']/*[local-name()='ItemGroup']/*[local-name()='PackageReference']")
-                         ?.Select(refElem => (refElem.Attribute("Include") == null ? "" : refElem.Attribute("Include").Value) + "," +
-                                            (refElem.Attribute("Version") == null ? "" : refElem.Attribute("Version").Value))
+                         ?.Select(refElem => GetProjectReferenceFromElement(refElem))
                          ?? Array.Empty<string>();
+        }
+         
+        private string GetProjectReferenceFromElement(XElement refElem)
+        {
+            string version, package = refElem.Attribute("Include")?.Value ?? "";
+
+            var versionAttribute = refElem.Attribute("Version");
+
+            if (versionAttribute != null)
+                version = versionAttribute.Value;
+            else // no version attribute, look for child element
+                version = refElem.Elements()
+                    .Where(elem => elem.Name.LocalName == "Version")
+                    .FirstOrDefault()?.Value ?? "";
+
+            return $"{package},{version}";
         }
 
         /// <summary>


### PR DESCRIPTION
Package reference version can be specified not only with xml-attributes like this ;
```xml
<ItemGroup>
    <PackageReference Include="NugetPackage" Version="2.5.4" />
</ItemGroup>
```
.. but also with version child-element like this ;
```xml
  <ItemGroup>
    <PackageReference Include="NugetPackage">
      <Version>2.5.4</Version>
    </PackageReference>
  </ItemGroup>
```

This PR fallbacks to try version-element if no version-attribute is found and should handle both scenarioes.
