### PR TITLE
Try to handle Package Versionings of all kinds

### DIFF
--- a/src/LicenseToUrlMappings.cs
+++ b/src/LicenseToUrlMappings.cs
@@ -74,8 +74,7 @@ namespace NugetUtility
             { "https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm", MS_EULA },
             { "http://go.microsoft.com/fwlink/?LinkId=329770", MS_EULA },
             { "http://go.microsoft.com/fwlink/?LinkId=529443", MS_EULA },
-            { "https://dotnet.microsoft.com/en/dotnet_library_license.htm", MS_EULA },
-            
+
             {"https://www.microsoft.com/web/webpi/eula/dotnet_library_license_non_redistributable.htm", MS_EULA_Non_Redistributable  },
             {"http://go.microsoft.com/fwlink/?LinkId=529444", MS_EULA_Non_Redistributable  }
         };

--- a/src/LicenseToUrlMappings.cs
+++ b/src/LicenseToUrlMappings.cs
@@ -74,7 +74,8 @@ namespace NugetUtility
             { "https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm", MS_EULA },
             { "http://go.microsoft.com/fwlink/?LinkId=329770", MS_EULA },
             { "http://go.microsoft.com/fwlink/?LinkId=529443", MS_EULA },
-
+            { "https://dotnet.microsoft.com/en/dotnet_library_license.htm", MS_EULA },
+            
             {"https://www.microsoft.com/web/webpi/eula/dotnet_library_license_non_redistributable.htm", MS_EULA_Non_Redistributable  },
             {"http://go.microsoft.com/fwlink/?LinkId=529444", MS_EULA_Non_Redistributable  }
         };

--- a/src/PackageNameAndVersion.cs
+++ b/src/PackageNameAndVersion.cs
@@ -1,0 +1,8 @@
+﻿namespace NugetUtility
+{
+    public class PackageNameAndVersion
+    {
+        public string Name;
+        public string Version;
+    }
+}

--- a/tests/NugetUtility.Tests/MethodsTests.cs
+++ b/tests/NugetUtility.Tests/MethodsTests.cs
@@ -38,7 +38,8 @@ namespace NugetUtility.Tests
         public async Task GetNugetInformationAsync_Should_Resolve_Projects()
         {
             var packages = _methods.GetProjectReferences(_projectPath);
-            var information = await _methods.GetNugetInformationAsync(_projectPath, packages);
+            var referencedpackages = packages.Select(p => { var split = p.Split(","); return new PackageNameAndVersion { Name = split[0], Version = split[1] }; });
+            var information = await _methods.GetNugetInformationAsync(_projectPath, referencedpackages);
 
             packages.Select(x => x.Split(',')[0].ToLower())
                 .Should()
@@ -50,11 +51,31 @@ namespace NugetUtility.Tests
         public async Task GetNugetInformationAsync_Should_Resolve_Missing_NuSpec_File(string package)
         {
             var packages = package.Split(';', System.StringSplitOptions.RemoveEmptyEntries);
-            var information = await _methods.GetNugetInformationAsync(_projectPath, packages);
+            var referencedpackages = packages.Select(p => { var split = p.Split(","); return new PackageNameAndVersion { Name = split[0], Version = split[1] }; });
+            var information = await _methods.GetNugetInformationAsync(_projectPath, referencedpackages);
 
             packages.Select(x => x.Split(',')[0])
                 .Should()
                 .BeEquivalentTo(information.Select(x => x.Value.Metadata.Id));
+        }
+
+        [TestCase("FluentValidation", "5.1.0.0")]
+        [TestCase("System.Linq", "(4.1.0,)")]
+        [TestCase("System.Linq", "[4.1.0]")]
+        [TestCase("System.Linq", "(,4.1.0]")]
+        [TestCase("System.Linq", "(,4.1.0)")]
+        [TestCase("System.Linq", "[4.1.0,4.3.0]")]
+        [TestCase("System.Linq", "(4.1.0,4.3.0)")]
+        [TestCase("System.Linq", "[4.1.0,4.3.0)")]
+        [Test]
+        public async Task GetNugetInformationAsync_Should_Properly_TreatAllAllowedNuSpecReferenceTypes(string package, string version)
+        {
+            var referencedpackages = new PackageNameAndVersion[] { new PackageNameAndVersion { Name = package, Version = version } };
+            var information = await _methods.GetNugetInformationAsync(_projectPath, referencedpackages);
+
+            var expectation = version.Trim(new char[] { '[', '(', ']', ')' }).Split(",", System.StringSplitOptions.RemoveEmptyEntries).Select(v => $"{package},{v}");
+            expectation.Should().BeEquivalentTo(information.Select(x => x.Key));
+            expectation.Should().BeEquivalentTo(information.Select(x => $"{x.Value.Metadata.Id},{x.Value.Metadata.Version}"));
         }
 
         [Test]


### PR DESCRIPTION
According to: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning a nuget package may specify a range of dependent versions that are compatible. This Pull Request tries to account for this by checking the licenses of the lowest and the highest explicitely specified package. 

There is a shortcoming with this approach, as exclusive specifications are not handled correctly. I think the best bet would be to let nuget resolve all packages and then use the resolved packages for license checking. Unfortunately I do not have any idea on how to acheive this.

This PR is the best I can come up with.