### PR TITLE
Fix typos s/licence/license/

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ dotnet-project-licenses -i projectFolder -u -o
 dotnet-project-licenses -i projectFolder -o --outfile ../../../another/folder/new-name.txt
 ```
 
-### Creates output json file of unique licences in a file 'licenses.json' in the current directory
+### Creates output json file of unique licenses in a file 'licenses.json' in the current directory
 
 ```ps
 dotnet-project-licenses -i projectFolder -u -o -j

--- a/src/Methods.cs
+++ b/src/Methods.cs
@@ -337,7 +337,7 @@ namespace NugetUtility
             if (!libraries.Any()) { return; }
 
             WriteOutput(Environment.NewLine + "References:", logLevel: LogLevel.Always);
-            WriteOutput(libraries.ToStringTable(new[] { "Reference", "Version", "Licence Type", "License" },
+            WriteOutput(libraries.ToStringTable(new[] { "Reference", "Version", "License Type", "License" },
                                                             a => a.PackageName ?? "---",
                                                             a => a.PackageVersion ?? "---",
                                                             a => a.LicenseType ?? "---",
@@ -395,7 +395,7 @@ namespace NugetUtility
                 sb.AppendLine();
             }
 
-            File.WriteAllText(GetOutputFilename("licences.txt"), sb.ToString());
+            File.WriteAllText(GetOutputFilename("licenses.txt"), sb.ToString());
         }
 
         public IValidationResult<KeyValuePair<string, Package>> ValidateLicenses(Dictionary<string, PackageList> projectPackages)

--- a/src/NugetUtility.csproj
+++ b/src/NugetUtility.csproj
@@ -9,7 +9,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageId>dotnet-project-licenses</PackageId>
     <ToolCommandName>dotnet-project-licenses</ToolCommandName>
-    <Version>2.2.6</Version>
+    <Version>2.2.7</Version>
     <Authors>Tom Chavakis</Authors>
     <Company>-</Company>
     <Title>.NET Core Tool to print a list of the licenses of a projects</Title>

--- a/src/PackageOptions.cs
+++ b/src/PackageOptions.cs
@@ -32,7 +32,7 @@ namespace NugetUtility
         [Option("licenseurl-to-license-mappings", Default = null, HelpText = "Simple json file of Dictinary<string,string> to override default mappings")]
         public string LicenseToUrlMappingsOption { get; set; }
 
-        [Option('o', "output", Default = false, HelpText = "Savas as text file (licenses.txt)")]
+        [Option('o', "output", Default = false, HelpText = "Saves as text file (licenses.txt)")]
         public bool TextOutput { get; set; }
 
         [Option("outfile", Default = null, HelpText = "Output filename")]

--- a/tests/NugetUtility.Tests/PackageOptionsTests.cs
+++ b/tests/NugetUtility.Tests/PackageOptionsTests.cs
@@ -26,5 +26,14 @@ namespace NugetUtility.Tests
                 .And.BeEquivalentTo(testMappings);
         }
 
+
+        [Test]
+        public void UniqueMappingsOption_When_Set_Should_Replace_Default_Mappings()
+        {
+            var options = new PackageOptions { UniqueOnly = true };
+            
+            options.UniqueOnly.Should().BeTrue();
+        }
+
     }
 }


### PR DESCRIPTION
It seems that this project uses license for [both the verb and the noum](https://www.grammarly.com/blog/licence-license/) and these places were just typos.

I noticed this when I generated both the JSON and TXT files and they were spelled differently.