### PR TITLE
F# support (*.fsproj)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ dotnet-project-licenses -i projectFolder
 
 ### Print unique licenses
 
-Values for the input may include a folder path, a Visual Studio '.sln' file, or a '.csproj' file.
+Values for the input may include a folder path, a Visual Studio '.sln' file, a '.csproj' or a '.fsproj' file.
 
 ```ps
 dotnet-project-licenses -i projectFolder -u

--- a/src/Methods.cs
+++ b/src/Methods.cs
@@ -202,19 +202,17 @@ namespace NugetUtility
             return licenses;
         }
 
-        public string GetProjectExtension(bool withWildcard = false)
-        {
-            return !withWildcard
-                ? ".csproj"
-                : "*.csproj";
-        }
+        public string[] GetProjectExtensions(bool withWildcard = false) =>
+            withWildcard
+                ? new[] { "*.csproj", "*.fsproj" }
+                : new[] { ".csproj", ".fsproj" };
 
-        /// <summary>
-        /// Retreive the project references from csproj file
-        /// </summary>
-        /// <param name="projectPath">The Project Path</param>
-        /// <returns></returns>
-        public IEnumerable<string> GetProjectReferences(string projectPath)
+/// <summary>
+/// Retreive the project references from csproj or fsproj file
+/// </summary>
+/// <param name="projectPath">The Project Path</param>
+/// <returns></returns>
+public IEnumerable<string> GetProjectReferences(string projectPath)
         {
             WriteOutput(() => $"Starting {nameof(GetProjectReferences)}...", logLevel: LogLevel.Verbose);
             if (string.IsNullOrWhiteSpace(projectPath))
@@ -222,7 +220,7 @@ namespace NugetUtility
                 throw new ArgumentNullException(projectPath);
             }
 
-            if (!projectPath.EndsWith(GetProjectExtension()))
+            if (!GetProjectExtensions().Any(projExt => projectPath.EndsWith(projExt)))
             {
                 projectPath = GetValidProjects(projectPath).GetAwaiter().GetResult().FirstOrDefault();
             }
@@ -643,17 +641,20 @@ namespace NugetUtility
         private async Task<IEnumerable<string>> GetValidProjects(string projectPath)
         {
             var pathInfo = new FileInfo(projectPath);
-            var extension = GetProjectExtension();
+            var extensions = GetProjectExtensions();
             IEnumerable<string> validProjects;
             switch (pathInfo.Extension)
             {
                 case ".sln":
                     validProjects = (await ParseSolution(pathInfo.FullName))
                         .Select(p => new FileInfo(Path.Combine(pathInfo.Directory.FullName, p)))
-                        .Where(p => p.Exists && p.Extension == extension)
+                        .Where(p => p.Exists && extensions.Contains(p.Extension))
                         .Select(p => p.FullName);
                     break;
                 case ".csproj":
+                    validProjects = new string[] { projectPath };
+                    break;
+                case ".fsproj":
                     validProjects = new string[] { projectPath };
                     break;
                 case ".json":
@@ -662,8 +663,11 @@ namespace NugetUtility
                         .ToList();
                     break;
                 default:
-                    validProjects = Directory
-                        .EnumerateFiles(projectPath, GetProjectExtension(withWildcard: true), SearchOption.AllDirectories);
+                    validProjects =
+                        GetProjectExtensions(withWildcard: true)
+                        .SelectMany(wildcardExtension =>
+                            Directory.EnumerateFiles(projectPath, wildcardExtension, SearchOption.AllDirectories)
+                        );
                     break;
             }
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -20,7 +20,7 @@ namespace NugetUtility
             if (string.IsNullOrWhiteSpace(options.ProjectDirectory))
             {
                 Console.WriteLine("ERROR(S):");
-                Console.WriteLine("-i\tInput the Directory Path (csproj file)");
+                Console.WriteLine("-i\tInput the Directory Path (csproj or fsproj file)");
 
                 return 1;
             }

--- a/tests/NugetUtility.Tests/MethodsTests.cs
+++ b/tests/NugetUtility.Tests/MethodsTests.cs
@@ -27,9 +27,9 @@ namespace NugetUtility.Tests
         }
 
         [Test]
-        public void GetProjectExtension_Should_Be_Csproj()
+        public void GetProjectExtension_Should_Be_CsprojOrFsProj()
         {
-            _methods.GetProjectExtension().Should().Be(".csproj");
+            _methods.GetProjectExtensions().Should().Contain(".csproj", ".fsproj");
         }
 
         [Test]


### PR DESCRIPTION
Using array of project extensions instead of a single string.