### PR TITLE
Add .NET 5.0 support

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -15,6 +15,10 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.1.100' # SDK Version to use.
+    - name: Setup dotnet 5.0.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x' # SDK Version to use (x uses the latest version).
     # dotnet restore
     - name: restore
       run: dotnet restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,12 @@ jobs:
         dotnet-version: '3.1.100' # SDK Version to use.
       env:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    - name: Setup dotnet 5.0.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x' # SDK Version to use (x uses the latest version).
+      env:
+        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     # dotnet restore
     - name: restore
       run: dotnet restore

--- a/src/NugetUtility.csproj
+++ b/src/NugetUtility.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <PackageType>DotnetTool</PackageType>

--- a/src/NugetUtility.csproj
+++ b/src/NugetUtility.csproj
@@ -9,7 +9,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageId>dotnet-project-licenses</PackageId>
     <ToolCommandName>dotnet-project-licenses</ToolCommandName>
-    <Version>2.2.10</Version>
+    <Version>2.2.11</Version>
     <Authors>Tom Chavakis</Authors>
     <Company>-</Company>
     <Title>.NET Core Tool to print a list of the licenses of a projects</Title>

--- a/tests/NugetUtility.Tests/NugetUtility.Tests.csproj
+++ b/tests/NugetUtility.Tests/NugetUtility.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Added .NET 5.0 support to execute tool inside mcr.microsoft.com/dotnet/sdk:5.0* docker build images.

@tomchavakis: please fix github workflows to add .NET 5.0 sdk during build process