### PR TITLE
Add new option: unique-by-package-name option to group packages only by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Usage: dotnet-project-licenses [options]
 | `-f, --output-directory` | Set Output Directory/Folder |
 | `--projects-filter` | Simple json file of a text array of projects to skip. Supports Ends with matching such as 'Tests.csproj' |
 | `--packages-filter` | Simple json file of a text array of packages to skip. Or a regular expression defined between two forward slashes '`/regex/`'. |
-| `-u, --unique` | (Default: false) Unique licenses list by Id/Version |
+| `-u, --unique` | (Default: false) Unique licenses list by Package Name(Id)/Version |
+| `--unique-by-package-name` | (Default: false) Unique licenses list only by Package Name (Id) |
 | `-p, --print` | (Default: true) Print licenses. |
 | `--export-license-texts` | Exports the raw license texts |
 | `--help` | Display this help screen. |
@@ -56,12 +57,20 @@ dotnet-project-licenses --help
 dotnet-project-licenses -i projectFolder
 ```
 
-### Print unique licenses
+### Print unique licenses (Package Name/Version)
 
 Values for the input may include a folder path, a Visual Studio '.sln' file, a '.csproj' or a '.fsproj' file.
 
 ```ps
 dotnet-project-licenses -i projectFolder -u
+```
+
+### Print unique licenses (only Package Name)
+
+Values for the input may include a folder path, a Visual Studio '.sln' file, a '.csproj' or a '.fsproj' file.
+
+```ps
+dotnet-project-licenses -i projectFolder --unique-by-package-name
 ```
 
 ### Creates output file of unique licenses in a plain text 'licenses.txt' file in current directory

--- a/src/Methods.cs
+++ b/src/Methods.cs
@@ -13,15 +13,13 @@ using System.Xml.XPath;
 using Newtonsoft.Json;
 using static NugetUtility.Utilties;
 
-namespace NugetUtility
-{
-    public class Methods
-    {
+namespace NugetUtility {
+    public class Methods {
         private const string fallbackPackageUrl = "https://www.nuget.org/api/v2/package/{0}/{1}";
         private const string nugetUrl = "https://api.nuget.org/v3-flatcontainer/";
         private const string deprecateNugetLicense = "https://aka.ms/deprecateLicenseUrl";
-        private static readonly Dictionary<Tuple<string, string>, Package> _requestCache = new Dictionary<Tuple<string, string>, Package>();
-        private static readonly Dictionary<Tuple<string, string>, string> _licenseFileCache = new Dictionary<Tuple<string, string>, string>();
+        private static readonly Dictionary<Tuple<string, string>, Package> _requestCache = new Dictionary<Tuple<string, string>, Package> ();
+        private static readonly Dictionary<Tuple<string, string>, string> _licenseFileCache = new Dictionary<Tuple<string, string>, string> ();
         /// <summary>
         /// See https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/
         /// </summary>
@@ -33,31 +31,25 @@ namespace NugetUtility
         private readonly PackageOptions _packageOptions;
         private readonly XmlSerializer _serializer;
 
-        internal static bool IgnoreSslCertificateErrorCallback(HttpRequestMessage message, System.Security.Cryptography.X509Certificates.X509Certificate2 cert, System.Security.Cryptography.X509Certificates.X509Chain chain, System.Net.Security.SslPolicyErrors sslPolicyErrors)
-            => true;
+        internal static bool IgnoreSslCertificateErrorCallback (HttpRequestMessage message, System.Security.Cryptography.X509Certificates.X509Certificate2 cert, System.Security.Cryptography.X509Certificates.X509Chain chain, System.Net.Security.SslPolicyErrors sslPolicyErrors) => true;
 
-        public Methods(PackageOptions packageOptions)
-        {
-            if (_httpClient is null)
-            {
-                var httpClientHandler = new HttpClientHandler
-                {
+        public Methods (PackageOptions packageOptions) {
+            if (_httpClient is null) {
+                var httpClientHandler = new HttpClientHandler {
                     AllowAutoRedirect = true,
                     MaxAutomaticRedirections = maxRedirects
                 };
-                if (packageOptions.IgnoreSslCertificateErrors)
-                {
-                    httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, sslPolicyErrors) => IgnoreSslCertificateErrorCallback(message, cert, chain, sslPolicyErrors);
+                if (packageOptions.IgnoreSslCertificateErrors) {
+                    httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, sslPolicyErrors) => IgnoreSslCertificateErrorCallback (message, cert, chain, sslPolicyErrors);
                 }
 
-                _httpClient = new HttpClient(httpClientHandler)
-                {
-                    BaseAddress = new Uri(nugetUrl),
-                    Timeout = TimeSpan.FromSeconds(timeout)
+                _httpClient = new HttpClient (httpClientHandler) {
+                    BaseAddress = new Uri (nugetUrl),
+                    Timeout = TimeSpan.FromSeconds (timeout)
                 };
             }
 
-            _serializer = new XmlSerializer(typeof(Package));
+            _serializer = new XmlSerializer (typeof (Package));
             _packageOptions = packageOptions;
             _licenseMappings = packageOptions.LicenseToUrlMappingsDictionary;
         }
@@ -68,20 +60,15 @@ namespace NugetUtility
         /// <param name="project">project name</param>
         /// <param name="packages">List of projects</param>
         /// <returns></returns>
-        public async Task<PackageList> GetNugetInformationAsync(string project, IEnumerable<PackageNameAndVersion> packages)
-        {
-            WriteOutput(Environment.NewLine + "project:" + project + Environment.NewLine, logLevel: LogLevel.Information);
-            var licenses = new PackageList();
-            foreach (var packageWithVersion in packages)
-            {
-                var versions = packageWithVersion.Version.Trim(new char[] { '[', ']', '(', ')' }).Split(",");
-                foreach (var version in versions)
-                {
-                    try
-                    {
-                        if (string.IsNullOrWhiteSpace(packageWithVersion.Name) || string.IsNullOrWhiteSpace(version))
-                        {
-                            WriteOutput($"Skipping invalid entry {packageWithVersion}", logLevel: LogLevel.Verbose);
+        public async Task<PackageList> GetNugetInformationAsync (string project, IEnumerable<PackageNameAndVersion> packages) {
+            WriteOutput (Environment.NewLine + "project:" + project + Environment.NewLine, logLevel : LogLevel.Information);
+            var licenses = new PackageList ();
+            foreach (var packageWithVersion in packages) {
+                var versions = packageWithVersion.Version.Trim (new char[] { '[', ']', '(', ')' }).Split (",");
+                foreach (var version in versions) {
+                    try {
+                        if (string.IsNullOrWhiteSpace (packageWithVersion.Name) || string.IsNullOrWhiteSpace (version)) {
+                            WriteOutput ($"Skipping invalid entry {packageWithVersion}", logLevel : LogLevel.Verbose);
                             continue;
                         }
 
@@ -91,202 +78,166 @@ namespace NugetUtility
                             continue;
                         }
 
-                        var lookupKey = Tuple.Create(packageWithVersion.Name, version);
+                        var lookupKey = Tuple.Create (packageWithVersion.Name, version);
 
-                        if (_requestCache.TryGetValue(lookupKey, out var package))
-                        {
-                            WriteOutput(packageWithVersion + " obtained from request cache.", logLevel: LogLevel.Information);
-                            licenses.TryAdd($"{packageWithVersion.Name},{version}", package);
+                        if (_requestCache.TryGetValue (lookupKey, out var package)) {
+                            WriteOutput (packageWithVersion + " obtained from request cache.", logLevel : LogLevel.Information);
+                            licenses.TryAdd ($"{packageWithVersion.Name},{version}", package);
                             continue;
                         }
 
                         // Search nuspec in local cache (Fix for linux distro)
-                        string userDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                        string userDir = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
 
-                        var nuspecPath = CreateNuSpecPath(userDir, version, packageWithVersion.Name);
+                        var nuspecPath = CreateNuSpecPath (userDir, version, packageWithVersion.Name);
                         //Linux: package file name could be lowercase
-                        if (IsLinux())
-                        {
+                        if (IsLinux ()) {
                             //Check package file
-                            if(!File.Exists(nuspecPath))
-                            {
+                            if (!File.Exists (nuspecPath)) {
                                 //Try lowercase
-                                nuspecPath = CreateNuSpecPath(userDir, version, packageWithVersion.Name?.ToLowerInvariant());
+                                nuspecPath = CreateNuSpecPath (userDir, version, packageWithVersion.Name?.ToLowerInvariant ());
                             }
                         }
 
-                        if (File.Exists(nuspecPath))
-                        {
-                            try
-                            {
-                                using var textReader = new StreamReader(nuspecPath);
-                                await ReadNuspecFile(project, licenses, packageWithVersion.Name, version, lookupKey, textReader);
+                        if (File.Exists (nuspecPath)) {
+                            try {
+                                using var textReader = new StreamReader (nuspecPath);
+                                await ReadNuspecFile (project, licenses, packageWithVersion.Name, version, lookupKey, textReader);
                                 continue;
-                            }
-                            catch(Exception exc)
-                            {
+                            } catch (Exception exc) {
                                 // Ignore errors in local cache, try online call
-                                WriteOutput($"ReadNuspecFile error, package '{packageWithVersion.Name}'", exc, LogLevel.Verbose);
+                                WriteOutput ($"ReadNuspecFile error, package '{packageWithVersion.Name}'", exc, LogLevel.Verbose);
                             }
-                        }
-                        else
-                        {
-                            WriteOutput($"Package '{packageWithVersion.Name}' not found in local cache ({nuspecPath})..", logLevel: LogLevel.Verbose);
+                        } else {
+                            WriteOutput ($"Package '{packageWithVersion.Name}' not found in local cache ({nuspecPath})..", logLevel : LogLevel.Verbose);
                         }
 
                         // Try dowload nuspec
-                        using var request = new HttpRequestMessage(HttpMethod.Get, $"{packageWithVersion.Name}/{version}/{packageWithVersion.Name}.nuspec");
-                        using var response = await _httpClient.SendAsync(request);
-                        if (!response.IsSuccessStatusCode)
-                        {
-                            WriteOutput($"{request.RequestUri} failed due to {response.StatusCode}!", logLevel: LogLevel.Warning);
-                            var fallbackResult = await GetNuGetPackageFileResult<Package>(packageWithVersion.Name, version, $"{packageWithVersion.Name}.nuspec");
-                            if (fallbackResult is Package)
-                            {
-                                licenses.Add($"{packageWithVersion.Name},{version}", fallbackResult);
-                                await this.AddTransitivePackages(project, licenses, fallbackResult);
+                        using var request = new HttpRequestMessage (HttpMethod.Get, $"{packageWithVersion.Name}/{version}/{packageWithVersion.Name}.nuspec");
+                        using var response = await _httpClient.SendAsync (request);
+                        if (!response.IsSuccessStatusCode) {
+                            WriteOutput ($"{request.RequestUri} failed due to {response.StatusCode}!", logLevel : LogLevel.Warning);
+                            var fallbackResult = await GetNuGetPackageFileResult<Package> (packageWithVersion.Name, version, $"{packageWithVersion.Name}.nuspec");
+                            if (fallbackResult is Package) {
+                                licenses.Add ($"{packageWithVersion.Name},{version}", fallbackResult);
+                                await this.AddTransitivePackages (project, licenses, fallbackResult);
                                 _requestCache[lookupKey] = fallbackResult;
-                                await HandleLicensing(fallbackResult);
-                            }
-                            else
-                            {
-                                licenses.Add($"{packageWithVersion.Name},{version}", new Package { Metadata = new Metadata { Version = version, Id = packageWithVersion.Name } });
+                                await HandleLicensing (fallbackResult);
+                            } else {
+                                licenses.Add ($"{packageWithVersion.Name},{version}", new Package { Metadata = new Metadata { Version = version, Id = packageWithVersion.Name } });
                             }
 
                             continue;
                         }
 
-                        WriteOutput($"Successfully received {request.RequestUri}", logLevel: LogLevel.Information);
-                        using (var responseText = await response.Content.ReadAsStreamAsync())
-                        using (var textReader = new StreamReader(responseText))
-                        {
-                            try
-                            {
-                                await ReadNuspecFile(project, licenses, packageWithVersion.Name, version, lookupKey, textReader);
-                            }
-                            catch (Exception e)
-                            {
-                                WriteOutput(e.Message, e, LogLevel.Error);
+                        WriteOutput ($"Successfully received {request.RequestUri}", logLevel : LogLevel.Information);
+                        using (var responseText = await response.Content.ReadAsStreamAsync ())
+                        using (var textReader = new StreamReader (responseText)) {
+                            try {
+                                await ReadNuspecFile (project, licenses, packageWithVersion.Name, version, lookupKey, textReader);
+                            } catch (Exception e) {
+                                WriteOutput (e.Message, e, LogLevel.Error);
                                 throw;
                             }
                         }
-                    }
-                    catch (Exception ex)
-                    {
-                        WriteOutput(ex.Message, ex, LogLevel.Error);
+                    } catch (Exception ex) {
+                        WriteOutput (ex.Message, ex, LogLevel.Error);
                     }
                 }
             }
 
             return licenses;
 
-            static bool IsLinux()
-            {
+            static bool IsLinux () {
 #if NET5_0_OR_GREATER
-                return OperatingSystem.IsLinux();
+                return OperatingSystem.IsLinux ();
 #else
-                return System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux);
+                return System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform (System.Runtime.InteropServices.OSPlatform.Linux);
 #endif
             }
 
-            static string CreateNuSpecPath(string userDir, string version, string packageName)
-                => Path.Combine(userDir, ".nuget", "packages", packageName, version, $"{packageName}.nuspec");
+            static string CreateNuSpecPath (string userDir, string version, string packageName) => Path.Combine (userDir, ".nuget", "packages", packageName, version, $"{packageName}.nuspec");
         }
 
-        private async Task ReadNuspecFile(string project, PackageList licenses, string package, string version, Tuple<string, string> lookupKey, StreamReader textReader)
-        {
-            if (_serializer.Deserialize(new NamespaceIgnorantXmlTextReader(textReader)) is Package result)
-            {
-                licenses.Add($"{package},{version}", result);
-                await this.AddTransitivePackages(project, licenses, result);
+        private async Task ReadNuspecFile (string project, PackageList licenses, string package, string version, Tuple<string, string> lookupKey, StreamReader textReader) {
+            if (_serializer.Deserialize (new NamespaceIgnorantXmlTextReader (textReader)) is Package result) {
+                licenses.Add ($"{package},{version}", result);
+                await this.AddTransitivePackages (project, licenses, result);
                 _requestCache[lookupKey] = result;
-                await HandleLicensing(result);
+                await HandleLicensing (result);
             }
         }
 
-        private async Task AddTransitivePackages(string project, PackageList licenses, Package result)
-        {
+        private async Task AddTransitivePackages (string project, PackageList licenses, Package result) {
             var groups = result.Metadata?.Dependencies?.Group;
-            if (_packageOptions.IncludeTransitive && groups != null)
-            {
-                foreach (var group in groups)
-                {
+            if (_packageOptions.IncludeTransitive && groups != null) {
+                foreach (var group in groups) {
                     var dependant =
                         group
                         .Dependency
-                        .Where(e => !licenses.Keys.Contains($"{e.Id},{e.Version}"))
-                        .Select(e => new PackageNameAndVersion { Name = e.Id, Version = e.Version });
+                        .Where (e => !licenses.Keys.Contains ($"{e.Id},{e.Version}"))
+                        .Select (e => new PackageNameAndVersion { Name = e.Id, Version = e.Version });
 
-                    var dependantPackages = await GetNugetInformationAsync(project, dependant);
-                    foreach (var dependantPackage in dependantPackages)
-                    {
-                        if (!licenses.ContainsKey(dependantPackage.Key))
-                        {
-                            licenses.Add(dependantPackage.Key, dependantPackage.Value);
+                    var dependantPackages = await GetNugetInformationAsync (project, dependant);
+                    foreach (var dependantPackage in dependantPackages) {
+                        if (!licenses.ContainsKey (dependantPackage.Key)) {
+                            licenses.Add (dependantPackage.Key, dependantPackage.Value);
                         }
                     }
                 }
             }
         }
 
-        public async Task<Dictionary<string, PackageList>> GetPackages()
-        {
-            WriteOutput(() => $"Starting {nameof(GetPackages)}...", logLevel: LogLevel.Verbose);
-            var licenses = new Dictionary<string, PackageList>();
-            var projectFiles = await GetValidProjects(_packageOptions.ProjectDirectory);
-            foreach (var projectFile in projectFiles)
-            {
-                var references = this.GetProjectReferences(projectFile);
-                var referencedPackages = references.Select((package) =>
-                {
-                    var split = package.Split(',');
+        public async Task<Dictionary<string, PackageList>> GetPackages () {
+            WriteOutput (() => $"Starting {nameof(GetPackages)}...", logLevel : LogLevel.Verbose);
+            var licenses = new Dictionary<string, PackageList> ();
+            var projectFiles = await GetValidProjects (_packageOptions.ProjectDirectory);
+            foreach (var projectFile in projectFiles) {
+                var references = this.GetProjectReferences (projectFile);
+                var referencedPackages = references.Select ((package) => {
+                    var split = package.Split (',');
                     return new PackageNameAndVersion { Name = split[0], Version = split[1] };
                 });
-                var currentProjectLicenses = await this.GetNugetInformationAsync(projectFile, referencedPackages);
+                var currentProjectLicenses = await this.GetNugetInformationAsync (projectFile, referencedPackages);
                 licenses[projectFile] = currentProjectLicenses;
             }
 
             return licenses;
         }
 
-        public string[] GetProjectExtensions(bool withWildcard = false) =>
+        public string[] GetProjectExtensions (bool withWildcard = false) =>
             withWildcard ?
-            new[] { "*.csproj", "*.fsproj" } :
-            new[] { ".csproj", ".fsproj" };
+            new [] { "*.csproj", "*.fsproj" } :
+            new [] { ".csproj", ".fsproj" };
 
         /// <summary>
         /// Retreive the project references from csproj or fsproj file
         /// </summary>
         /// <param name="projectPath">The Project Path</param>
         /// <returns></returns>
-        public IEnumerable<string> GetProjectReferences(string projectPath)
-        {
-            WriteOutput(() => $"Starting {nameof(GetProjectReferences)}...", logLevel: LogLevel.Verbose);
-            if (string.IsNullOrWhiteSpace(projectPath))
-            {
-                throw new ArgumentNullException(projectPath);
+        public IEnumerable<string> GetProjectReferences (string projectPath) {
+            WriteOutput (() => $"Starting {nameof(GetProjectReferences)}...", logLevel : LogLevel.Verbose);
+            if (string.IsNullOrWhiteSpace (projectPath)) {
+                throw new ArgumentNullException (projectPath);
             }
 
-            if (!GetProjectExtensions().Any(projExt => projectPath.EndsWith(projExt)))
-            {
-                projectPath = GetValidProjects(projectPath).GetAwaiter().GetResult().FirstOrDefault();
+            if (!GetProjectExtensions ().Any (projExt => projectPath.EndsWith (projExt))) {
+                projectPath = GetValidProjects (projectPath).GetAwaiter ().GetResult ().FirstOrDefault ();
             }
 
-            if (projectPath is null)
-            {
-                throw new FileNotFoundException();
+            if (projectPath is null) {
+                throw new FileNotFoundException ();
             }
 
             // First try to get references from new project file format
-            var references = GetProjectReferencesFromNewProjectFile(projectPath);
+            var references = GetProjectReferencesFromNewProjectFile (projectPath);
 
             // Then if needed from old packages.config
-            if (!references.Any())
-            {
-                references = GetProjectReferencesFromPackagesConfig(projectPath);
+            if (!references.Any ()) {
+                references = GetProjectReferencesFromPackagesConfig (projectPath);
             }
 
-            return references ?? Array.Empty<string>();
+            return references ?? Array.Empty<string> ();
         }
 
         /// <summary>
@@ -294,121 +245,123 @@ namespace NugetUtility
         /// </summary>
         /// <param name="packages"></param>
         /// <returns></returns>
-        public List<LibraryInfo> MapPackagesToLibraryInfo(Dictionary<string, PackageList> packages)
-        {
-            WriteOutput(() => $"Starting {nameof(MapPackagesToLibraryInfo)}...", logLevel: LogLevel.Verbose);
-            var libraryInfos = new List<LibraryInfo>(256);
-            foreach (var packageList in packages)
-            {
-                foreach (var item in packageList.Value.Select(p => p.Value))
-                {
-                    var info = MapPackageToLibraryInfo(item, packageList.Key);
-                    libraryInfos.Add(info);
+        public List<LibraryInfo> MapPackagesToLibraryInfo (Dictionary<string, PackageList> packages) {
+            WriteOutput (() => $"Starting {nameof(MapPackagesToLibraryInfo)}...", logLevel : LogLevel.Verbose);
+            var libraryInfos = new List<LibraryInfo> (256);
+            foreach (var packageList in packages) {
+                foreach (var item in packageList.Value.Select (p => p.Value)) {
+                    var info = MapPackageToLibraryInfo (item, packageList.Key);
+                    libraryInfos.Add (info);
                 }
             }
 
             // merge in missing manual items where there wasn't a package
-            var missedManualItems = _packageOptions.ManualInformation.Except(libraryInfos, LibraryNameAndVersionComparer.Default);
-            foreach (var missed in missedManualItems)
-            {
-                libraryInfos.Add(missed);
+            var missedManualItems = _packageOptions.ManualInformation.Except (libraryInfos, LibraryNameAndVersionComparer.Default);
+            foreach (var missed in missedManualItems) {
+                libraryInfos.Add (missed);
             }
 
-            if (_packageOptions.UniqueOnly)
-            {
+            if (_packageOptions.UniqueByPackageName) {
+                _packageOptions.UniqueOnly = false;
+
                 libraryInfos = libraryInfos
-                    .GroupBy(x => new { x.PackageName, x.PackageVersion })
-                    .Select(g =>
-                    {
-                        var first = g.First();
-                        return new LibraryInfo
-                        {
+                    .GroupBy (x => new { x.PackageName })
+                    .Select (g => {
+                        var first = g.First ();
+                        return new LibraryInfo {
                             PackageName = first.PackageName,
-                            PackageVersion = first.PackageVersion,
-                            PackageUrl = first.PackageUrl,
-                            Copyright = first.Copyright,
-                            Authors = first.Authors,
-                            Description = first.Description,
-                            LicenseType = first.LicenseType,
-                            LicenseUrl = first.LicenseUrl,
-                            Projects = _packageOptions.IncludeProjectFile ? string.Join(";", g.Select(p => p.Projects)) : null
+                                PackageVersion = first.PackageVersion,
+                                PackageUrl = first.PackageUrl,
+                                Copyright = first.Copyright,
+                                Authors = first.Authors,
+                                Description = first.Description,
+                                LicenseType = first.LicenseType,
+                                LicenseUrl = first.LicenseUrl,
+                                Projects = _packageOptions.IncludeProjectFile ? string.Join (";", g.Select (p => p.Projects)) : null
                         };
                     })
-                    .ToList();
+                    .ToList ();
+            }
+
+            if (_packageOptions.UniqueOnly) {
+                libraryInfos = libraryInfos
+                    .GroupBy (x => new { x.PackageName, x.PackageVersion })
+                    .Select (g => {
+                        var first = g.First ();
+                        return new LibraryInfo {
+                            PackageName = first.PackageName,
+                                PackageVersion = first.PackageVersion,
+                                PackageUrl = first.PackageUrl,
+                                Copyright = first.Copyright,
+                                Authors = first.Authors,
+                                Description = first.Description,
+                                LicenseType = first.LicenseType,
+                                LicenseUrl = first.LicenseUrl,
+                                Projects = _packageOptions.IncludeProjectFile ? string.Join (";", g.Select (p => p.Projects)) : null
+                        };
+                    })
+                    .ToList ();
             }
 
             return libraryInfos
-                .OrderBy(p => p.PackageName)
-                .ToList();
+                .OrderBy (p => p.PackageName)
+                .ToList ();
         }
 
-        private LibraryInfo MapPackageToLibraryInfo(Package item, string projectFile)
-        {
+        private LibraryInfo MapPackageToLibraryInfo (Package item, string projectFile) {
             string licenseType = item.Metadata.License?.Text ?? null;
             string licenseUrl = item.Metadata.LicenseUrl ?? null;
 
-            if (licenseUrl is string && string.IsNullOrWhiteSpace(licenseType))
-            {
-                if (_licenseMappings.TryGetValue(licenseUrl, out var license))
-                {
+            if (licenseUrl is string && string.IsNullOrWhiteSpace (licenseType)) {
+                if (_licenseMappings.TryGetValue (licenseUrl, out var license)) {
                     licenseType = license;
                 }
             }
 
             var manual = _packageOptions.ManualInformation
-                .FirstOrDefault(f => f.PackageName == item.Metadata.Id && f.PackageVersion == item.Metadata.Version);
+                .FirstOrDefault (f => f.PackageName == item.Metadata.Id && f.PackageVersion == item.Metadata.Version);
 
-            return new LibraryInfo
-            {
+            return new LibraryInfo {
                 PackageName = item.Metadata.Id ?? string.Empty,
-                PackageVersion = item.Metadata.Version ?? string.Empty,
-                PackageUrl = !string.IsNullOrWhiteSpace(manual?.PackageUrl) ?
+                    PackageVersion = item.Metadata.Version ?? string.Empty,
+                    PackageUrl = !string.IsNullOrWhiteSpace (manual?.PackageUrl) ?
                     manual.PackageUrl :
                     item.Metadata.ProjectUrl ?? string.Empty,
-                Copyright = item.Metadata.Copyright ?? string.Empty,
-                Authors = manual?.Authors ?? item.Metadata.Authors?.Split(',') ?? new string[] { },
-                Description = !string.IsNullOrWhiteSpace(manual?.Description) ?
+                    Copyright = item.Metadata.Copyright ?? string.Empty,
+                    Authors = manual?.Authors ?? item.Metadata.Authors?.Split (',') ?? new string[] { },
+                    Description = !string.IsNullOrWhiteSpace (manual?.Description) ?
                     manual.Description :
                     item.Metadata.Description ?? string.Empty,
-                LicenseType = manual?.LicenseType ?? licenseType ?? string.Empty,
-                LicenseUrl = manual?.LicenseUrl ?? licenseUrl ?? string.Empty,
-                Projects = _packageOptions.IncludeProjectFile ? projectFile : null
+                    LicenseType = manual?.LicenseType ?? licenseType ?? string.Empty,
+                    LicenseUrl = manual?.LicenseUrl ?? licenseUrl ?? string.Empty,
+                    Projects = _packageOptions.IncludeProjectFile ? projectFile : null
             };
         }
 
-        public IValidationResult<KeyValuePair<string, Package>> ValidateLicenses(Dictionary<string, PackageList> projectPackages)
-        {
-            if (_packageOptions.AllowedLicenseType.Count == 0)
-            {
+        public IValidationResult<KeyValuePair<string, Package>> ValidateLicenses (Dictionary<string, PackageList> projectPackages) {
+            if (_packageOptions.AllowedLicenseType.Count == 0) {
                 return new ValidationResult<KeyValuePair<string, Package>> { IsValid = true };
             }
 
-            WriteOutput(() => $"Starting {nameof(ValidateLicenses)}...", logLevel: LogLevel.Verbose);
+            WriteOutput (() => $"Starting {nameof(ValidateLicenses)}...", logLevel : LogLevel.Verbose);
             var invalidPackages = projectPackages
-                .SelectMany(kvp => kvp.Value.Select(p => new KeyValuePair<string, Package>(kvp.Key, p.Value)))
-                .Where(p => !_packageOptions.AllowedLicenseType.Any(allowed =>
-                {
-                    if (p.Value.Metadata.LicenseUrl is string licenseUrl)
-                    {
-                        if (_licenseMappings.TryGetValue(licenseUrl, out var license))
-                        {
+                .SelectMany (kvp => kvp.Value.Select (p => new KeyValuePair<string, Package> (kvp.Key, p.Value)))
+                .Where (p => !_packageOptions.AllowedLicenseType.Any (allowed => {
+                    if (p.Value.Metadata.LicenseUrl is string licenseUrl) {
+                        if (_licenseMappings.TryGetValue (licenseUrl, out var license)) {
                             return allowed == license;
                         }
 
-                        if (p.Value.Metadata.LicenseUrl?.Contains(allowed, StringComparison.OrdinalIgnoreCase) == true)
-                        {
+                        if (p.Value.Metadata.LicenseUrl?.Contains (allowed, StringComparison.OrdinalIgnoreCase) == true) {
                             return true;
                         }
                     }
 
-                    if (p.Value.Metadata.License.IsLicenseFile())
-                    {
-                        var key = Tuple.Create(p.Value.Metadata.Id, p.Value.Metadata.Version);
+                    if (p.Value.Metadata.License.IsLicenseFile ()) {
+                        var key = Tuple.Create (p.Value.Metadata.Id, p.Value.Metadata.Version);
 
-                        if (_licenseFileCache.TryGetValue(key, out var licenseText))
-                        {
-                            if (licenseText.Contains(allowed, StringComparison.OrdinalIgnoreCase))
-                            {
+                        if (_licenseFileCache.TryGetValue (key, out var licenseText)) {
+                            if (licenseText.Contains (allowed, StringComparison.OrdinalIgnoreCase)) {
                                 p.Value.Metadata.License.Text = allowed;
                                 return true;
                             }
@@ -417,122 +370,104 @@ namespace NugetUtility
 
                     return allowed == p.Value.Metadata.License?.Text;
                 }))
-                .ToList();
+                .ToList ();
 
             return new ValidationResult<KeyValuePair<string, Package>> { IsValid = invalidPackages.Count == 0, InvalidPackages = invalidPackages };
         }
 
-        public ValidationResult<LibraryInfo> ValidateLicenses(List<LibraryInfo> projectPackages)
-        {
-            if (_packageOptions.AllowedLicenseType.Count == 0)
-            {
+        public ValidationResult<LibraryInfo> ValidateLicenses (List<LibraryInfo> projectPackages) {
+            if (_packageOptions.AllowedLicenseType.Count == 0) {
                 return new ValidationResult<LibraryInfo> { IsValid = true };
             }
 
-            WriteOutput(() => $"Starting {nameof(ValidateLicenses)}...", logLevel: LogLevel.Verbose);
+            WriteOutput (() => $"Starting {nameof(ValidateLicenses)}...", logLevel : LogLevel.Verbose);
             var invalidPackages = projectPackages
-                .Where(p => !_packageOptions.AllowedLicenseType.Any(allowed =>
-                {
-                    if (p.LicenseUrl is string licenseUrl)
-                    {
-                        if (_licenseMappings.TryGetValue(licenseUrl, out var license))
-                        {
+                .Where (p => !_packageOptions.AllowedLicenseType.Any (allowed => {
+                    if (p.LicenseUrl is string licenseUrl) {
+                        if (_licenseMappings.TryGetValue (licenseUrl, out var license)) {
                             return allowed == license;
                         }
 
-                        if (p.LicenseUrl?.Contains(allowed, StringComparison.OrdinalIgnoreCase) == true)
-                        {
+                        if (p.LicenseUrl?.Contains (allowed, StringComparison.OrdinalIgnoreCase) == true) {
                             return true;
                         }
                     }
 
                     return allowed == p.LicenseType;
                 }))
-                .ToList();
+                .ToList ();
 
             return new ValidationResult<LibraryInfo> { IsValid = invalidPackages.Count == 0, InvalidPackages = invalidPackages };
         }
 
-        private async Task<T> GetNuGetPackageFileResult<T>(string packageName, string versionNumber, string fileInPackage)
-        where T : class
-        {
-            if (string.IsNullOrWhiteSpace(packageName) || string.IsNullOrWhiteSpace(versionNumber)) { return await Task.FromResult<T>(null); }
-            var fallbackEndpoint = new Uri(string.Format(fallbackPackageUrl, packageName, versionNumber));
-            WriteOutput(() => "Attempting to download: " + fallbackEndpoint.ToString(), logLevel: LogLevel.Verbose);
-            using var packageRequest = new HttpRequestMessage(HttpMethod.Get, fallbackEndpoint);
-            using var packageResponse = await _httpClient.SendAsync(packageRequest, CancellationToken.None);
-            if (!packageResponse.IsSuccessStatusCode)
-            {
-                WriteOutput($"{packageRequest.RequestUri} failed due to {packageResponse.StatusCode}!", logLevel: LogLevel.Warning);
+        private async Task<T> GetNuGetPackageFileResult<T> (string packageName, string versionNumber, string fileInPackage)
+        where T : class {
+            if (string.IsNullOrWhiteSpace (packageName) || string.IsNullOrWhiteSpace (versionNumber)) { return await Task.FromResult<T> (null); }
+            var fallbackEndpoint = new Uri (string.Format (fallbackPackageUrl, packageName, versionNumber));
+            WriteOutput (() => "Attempting to download: " + fallbackEndpoint.ToString (), logLevel : LogLevel.Verbose);
+            using var packageRequest = new HttpRequestMessage (HttpMethod.Get, fallbackEndpoint);
+            using var packageResponse = await _httpClient.SendAsync (packageRequest, CancellationToken.None);
+            if (!packageResponse.IsSuccessStatusCode) {
+                WriteOutput ($"{packageRequest.RequestUri} failed due to {packageResponse.StatusCode}!", logLevel : LogLevel.Warning);
                 return null;
             }
 
-            using var fileStream = new MemoryStream();
-            await packageResponse.Content.CopyToAsync(fileStream);
+            using var fileStream = new MemoryStream ();
+            await packageResponse.Content.CopyToAsync (fileStream);
 
-            using var archive = new ZipArchive(fileStream, ZipArchiveMode.Read);
-            var entry = archive.GetEntry(fileInPackage);
-            if (entry is null)
-            {
-                WriteOutput(() => $"{fileInPackage} was not found in NuGet Package: {packageName}", logLevel: LogLevel.Verbose);
+            using var archive = new ZipArchive (fileStream, ZipArchiveMode.Read);
+            var entry = archive.GetEntry (fileInPackage);
+            if (entry is null) {
+                WriteOutput (() => $"{fileInPackage} was not found in NuGet Package: {packageName}", logLevel : LogLevel.Verbose);
                 return null;
             }
-            WriteOutput(() => $"Attempting to read: {fileInPackage}", logLevel: LogLevel.Verbose);
-            using var entryStream = entry.Open();
-            using var textReader = new StreamReader(entryStream);
-            var typeT = typeof(T);
-            if (typeT == typeof(Package))
-            {
-                if (_serializer.Deserialize(new NamespaceIgnorantXmlTextReader(textReader)) is T result)
-                {
-                    return (T)result;
+            WriteOutput (() => $"Attempting to read: {fileInPackage}", logLevel : LogLevel.Verbose);
+            using var entryStream = entry.Open ();
+            using var textReader = new StreamReader (entryStream);
+            var typeT = typeof (T);
+            if (typeT == typeof (Package)) {
+                if (_serializer.Deserialize (new NamespaceIgnorantXmlTextReader (textReader)) is T result) {
+                    return (T) result;
                 }
-            }
-            else if (typeT == typeof(string))
-            {
-                return await textReader.ReadToEndAsync() as T;
+            } else if (typeT == typeof (string)) {
+                return await textReader.ReadToEndAsync () as T;
             }
 
-            throw new ArgumentException($"{typeT.FullName} isn't supported!");
+            throw new ArgumentException ($"{typeT.FullName} isn't supported!");
         }
 
-        private IEnumerable<string> GetFilteredProjects(IEnumerable<string> projects)
-        {
-            if (_packageOptions.ProjectFilter.Count == 0)
-            {
+        private IEnumerable<string> GetFilteredProjects (IEnumerable<string> projects) {
+            if (_packageOptions.ProjectFilter.Count == 0) {
                 return projects;
             }
 
-            var filteredProjects = projects.Where(project => !_packageOptions.ProjectFilter
-               .Any(projectToSkip =>
-                  project.Contains(projectToSkip, StringComparison.OrdinalIgnoreCase)
-               )).ToList();
+            var filteredProjects = projects.Where (project => !_packageOptions.ProjectFilter
+                .Any (projectToSkip =>
+                    project.Contains (projectToSkip, StringComparison.OrdinalIgnoreCase)
+                )).ToList ();
 
-            WriteOutput(() => $"Filtered Project Files {Environment.NewLine}", logLevel: LogLevel.Verbose);
-            WriteOutput(() => string.Join(Environment.NewLine, filteredProjects.ToArray()), logLevel: LogLevel.Verbose);
+            WriteOutput (() => $"Filtered Project Files {Environment.NewLine}", logLevel : LogLevel.Verbose);
+            WriteOutput (() => string.Join (Environment.NewLine, filteredProjects.ToArray ()), logLevel : LogLevel.Verbose);
 
             return filteredProjects;
         }
 
-        private async Task HandleLicensing(Package package)
-        {
+        private async Task HandleLicensing (Package package) {
             if (package?.Metadata is null) { return; }
             if (package.Metadata.LicenseUrl is string licenseUrl &&
-                package.Metadata.License?.Text is null)
-            {
-                if (_licenseMappings.TryGetValue(licenseUrl, out var mappedLicense))
-                {
+                package.Metadata.License?.Text is null) {
+                if (_licenseMappings.TryGetValue (licenseUrl, out var mappedLicense)) {
                     package.Metadata.License = new License { Text = mappedLicense };
                 }
             }
 
-            if (!package.Metadata.License.IsLicenseFile() || _packageOptions.AllowedLicenseType.Count == 0) { return; }
+            if (!package.Metadata.License.IsLicenseFile () || _packageOptions.AllowedLicenseType.Count == 0) { return; }
 
-            var key = Tuple.Create(package.Metadata.Id, package.Metadata.Version);
+            var key = Tuple.Create (package.Metadata.Id, package.Metadata.Version);
 
-            if (_licenseFileCache.TryGetValue(key, out _)) { return; }
+            if (_licenseFileCache.TryGetValue (key, out _)) { return; }
 
-            _licenseFileCache[key] = await GetNuGetPackageFileResult<string>(package.Metadata.Id, package.Metadata.Version, package.Metadata.License.Text);
+            _licenseFileCache[key] = await GetNuGetPackageFileResult<string> (package.Metadata.Id, package.Metadata.Version, package.Metadata.License.Text);
         }
 
         private string GetOutputFilename (string defaultName) {
@@ -567,29 +502,27 @@ namespace NugetUtility
         /// </summary>
         /// <param name="projectPath">The Project Path</param>
         /// <returns></returns>
-        private IEnumerable<string> GetProjectReferencesFromNewProjectFile(string projectPath)
-        {
-            var projDefinition = XDocument.Load(projectPath);
+        private IEnumerable<string> GetProjectReferencesFromNewProjectFile (string projectPath) {
+            var projDefinition = XDocument.Load (projectPath);
 
             // Uses an XPath instead of direct navigation (using Elements("…")) as the project file may use xml namespaces
             return projDefinition?
-                .XPathSelectElements("/*[local-name()='Project']/*[local-name()='ItemGroup']/*[local-name()='PackageReference']")?
-                .Select(refElem => GetProjectReferenceFromElement(refElem)) ??
-                Array.Empty<string>();
+                .XPathSelectElements ("/*[local-name()='Project']/*[local-name()='ItemGroup']/*[local-name()='PackageReference']") ?
+                .Select (refElem => GetProjectReferenceFromElement (refElem)) ??
+                Array.Empty<string> ();
         }
 
-        private string GetProjectReferenceFromElement(XElement refElem)
-        {
-            string version, package = refElem.Attribute("Include")?.Value ?? string.Empty;
+        private string GetProjectReferenceFromElement (XElement refElem) {
+            string version, package = refElem.Attribute ("Include")?.Value ?? string.Empty;
 
-            var versionAttribute = refElem.Attribute("Version");
+            var versionAttribute = refElem.Attribute ("Version");
 
             if (versionAttribute != null)
                 version = versionAttribute.Value;
             else // no version attribute, look for child element
-                version = refElem.Elements()
-                .Where(elem => elem.Name.LocalName == "Version")
-                .FirstOrDefault()?.Value ?? string.Empty;
+                version = refElem.Elements ()
+                .Where (elem => elem.Name.LocalName == "Version")
+                .FirstOrDefault ()?.Value ?? string.Empty;
 
             return $"{package},{version}";
         }
@@ -599,36 +532,32 @@ namespace NugetUtility
         /// </summary>
         /// <param name="projectPath">The Project Path</param>
         /// <returns></returns>
-        private IEnumerable<string> GetProjectReferencesFromPackagesConfig(string projectPath)
-        {
-            var dir = Path.GetDirectoryName(projectPath);
-            var packagesFile = Path.Join(dir, "packages.config");
+        private IEnumerable<string> GetProjectReferencesFromPackagesConfig (string projectPath) {
+            var dir = Path.GetDirectoryName (projectPath);
+            var packagesFile = Path.Join (dir, "packages.config");
 
-            if (File.Exists(packagesFile))
-            {
-                var packagesConfig = XDocument.Load(packagesFile);
+            if (File.Exists (packagesFile)) {
+                var packagesConfig = XDocument.Load (packagesFile);
 
                 return packagesConfig?
-                    .Element("packages")?
-                    .Elements("package")?
-                    .Select(refElem => (refElem.Attribute("id")?.Value ?? string.Empty) + "," + (refElem.Attribute("version")?.Value ?? string.Empty));
+                    .Element ("packages") ?
+                    .Elements ("package") ?
+                    .Select (refElem => (refElem.Attribute ("id")?.Value ?? string.Empty) + "," + (refElem.Attribute ("version")?.Value ?? string.Empty));
             }
 
-            return Array.Empty<string>();
+            return Array.Empty<string> ();
         }
 
-        private async Task<IEnumerable<string>> GetValidProjects(string projectPath)
-        {
-            var pathInfo = new FileInfo(projectPath);
-            var extensions = GetProjectExtensions();
+        private async Task<IEnumerable<string>> GetValidProjects (string projectPath) {
+            var pathInfo = new FileInfo (projectPath);
+            var extensions = GetProjectExtensions ();
             IEnumerable<string> validProjects;
-            switch (pathInfo.Extension)
-            {
+            switch (pathInfo.Extension) {
                 case ".sln":
-                    validProjects = (await ParseSolution(pathInfo.FullName))
-                        .Select(p => new FileInfo(Path.Combine(pathInfo.Directory.FullName, p)))
-                        .Where(p => p.Exists && extensions.Contains(p.Extension))
-                        .Select(p => p.FullName);
+                    validProjects = (await ParseSolution (pathInfo.FullName))
+                        .Select (p => new FileInfo (Path.Combine (pathInfo.Directory.FullName, p)))
+                        .Where (p => p.Exists && extensions.Contains (p.Extension))
+                        .Select (p => p.FullName);
                     break;
                 case ".csproj":
                     validProjects = new string[] { projectPath };
@@ -637,46 +566,42 @@ namespace NugetUtility
                     validProjects = new string[] { projectPath };
                     break;
                 case ".json":
-                    validProjects = ReadListFromFile<string>(projectPath)
-                        .Select(x => x.EnsureCorrectPathCharacter())
-                        .ToList();
+                    validProjects = ReadListFromFile<string> (projectPath)
+                        .Select (x => x.EnsureCorrectPathCharacter ())
+                        .ToList ();
                     break;
                 default:
                     validProjects =
-                        GetProjectExtensions(withWildcard: true)
-                        .SelectMany(wildcardExtension =>
-                           Directory.EnumerateFiles(projectPath, wildcardExtension, SearchOption.AllDirectories)
+                        GetProjectExtensions (withWildcard: true)
+                        .SelectMany (wildcardExtension =>
+                            Directory.EnumerateFiles (projectPath, wildcardExtension, SearchOption.AllDirectories)
                         );
                     break;
             }
 
-            WriteOutput(() => $"Discovered Project Files {Environment.NewLine}", logLevel: LogLevel.Verbose);
-            WriteOutput(() => string.Join(Environment.NewLine, validProjects.ToArray()), logLevel: LogLevel.Verbose);
+            WriteOutput (() => $"Discovered Project Files {Environment.NewLine}", logLevel : LogLevel.Verbose);
+            WriteOutput (() => string.Join (Environment.NewLine, validProjects.ToArray ()), logLevel : LogLevel.Verbose);
 
-            return GetFilteredProjects(validProjects);
+            return GetFilteredProjects (validProjects);
         }
 
-        private async Task<IEnumerable<string>> ParseSolution(string fullName)
-        {
-            var solutionFile = new FileInfo(fullName);
-            if (!solutionFile.Exists) { throw new FileNotFoundException(fullName); }
-            var projectFiles = new List<string>(250);
+        private async Task<IEnumerable<string>> ParseSolution (string fullName) {
+            var solutionFile = new FileInfo (fullName);
+            if (!solutionFile.Exists) { throw new FileNotFoundException (fullName); }
+            var projectFiles = new List<string> (250);
 
-            using (var fileStream = solutionFile.OpenRead())
-            using (var streamReader = new StreamReader(fileStream))
-            {
-                while (await streamReader.ReadLineAsync() is string line)
-                {
-                    if (!line.StartsWith("Project")) { continue; }
-                    var segments = line.Split(',');
+            using (var fileStream = solutionFile.OpenRead ())
+            using (var streamReader = new StreamReader (fileStream)) {
+                while (await streamReader.ReadLineAsync () is string line) {
+                    if (!line.StartsWith ("Project")) { continue; }
+                    var segments = line.Split (',');
                     if (segments.Length < 2) { continue; }
-                    projectFiles.Add(segments[1].EnsureCorrectPathCharacter().Trim('"'));
+                    projectFiles.Add (segments[1].EnsureCorrectPathCharacter ().Trim ('"'));
                 }
             }
 
             return projectFiles;
         }
-
 
         /// <summary>
         /// Downloads the nuget package file and read the licence file
@@ -685,59 +610,47 @@ namespace NugetUtility
         /// <param name="licenseFile"></param>
         /// <param name="version"></param>
         /// <returns></returns>
-        public async Task<bool> GetLicenceFromNpkgFile(string package, string licenseFile, string version)
-        {
+        public async Task<bool> GetLicenceFromNpkgFile (string package, string licenseFile, string version) {
             bool result = false;
-            var nupkgEndpoint = new Uri(string.Format(fallbackPackageUrl, package, version));
-            WriteOutput(() => $"Attempting to download: {nupkgEndpoint}", logLevel: LogLevel.Verbose);
-            using var packageRequest = new HttpRequestMessage(HttpMethod.Get, nupkgEndpoint);
-            using var packageResponse = await _httpClient.SendAsync(packageRequest, CancellationToken.None);
+            var nupkgEndpoint = new Uri (string.Format (fallbackPackageUrl, package, version));
+            WriteOutput (() => $"Attempting to download: {nupkgEndpoint}", logLevel : LogLevel.Verbose);
+            using var packageRequest = new HttpRequestMessage (HttpMethod.Get, nupkgEndpoint);
+            using var packageResponse = await _httpClient.SendAsync (packageRequest, CancellationToken.None);
 
-            if (!packageResponse.IsSuccessStatusCode)
-            {
-                WriteOutput($"{packageRequest.RequestUri} failed due to {packageResponse.StatusCode}!", logLevel: LogLevel.Warning);
+            if (!packageResponse.IsSuccessStatusCode) {
+                WriteOutput ($"{packageRequest.RequestUri} failed due to {packageResponse.StatusCode}!", logLevel : LogLevel.Warning);
                 return false;
             }
 
-            var directory = GetExportDirectory();
-            var outpath = Path.Combine(directory, $"{package}_{version}.nupkg.zip");
+            var directory = GetExportDirectory ();
+            var outpath = Path.Combine (directory, $"{package}_{version}.nupkg.zip");
 
-            using (var fileStream = File.OpenWrite(outpath))
-            {
-                try
-                {
-                    await packageResponse.Content.CopyToAsync(fileStream);
-                }
-                catch (Exception)
-                {
+            using (var fileStream = File.OpenWrite (outpath)) {
+                try {
+                    await packageResponse.Content.CopyToAsync (fileStream);
+                } catch (Exception) {
                     return false;
                 }
             }
 
-            using (ZipArchive archive = ZipFile.OpenRead(outpath))
-            {
-                var sample = archive.GetEntry(licenseFile);
-                if (sample != null)
-                {
-                    var t = sample.Open();
-                    if (t != null && t.CanRead)
-                    {
-                        var libTxt = outpath.Replace(".nupkg.zip", ".txt");
-                        using var fileStream = File.OpenWrite(libTxt);
-                        try
-                        {
-                            await t.CopyToAsync(fileStream);
+            using (ZipArchive archive = ZipFile.OpenRead (outpath)) {
+                var sample = archive.GetEntry (licenseFile);
+                if (sample != null) {
+                    var t = sample.Open ();
+                    if (t != null && t.CanRead) {
+                        var libTxt = outpath.Replace (".nupkg.zip", ".txt");
+                        using var fileStream = File.OpenWrite (libTxt);
+                        try {
+                            await t.CopyToAsync (fileStream);
                             result = true;
-                        }
-                        catch (Exception)
-                        {
+                        } catch (Exception) {
                             return false;
                         }
                     }
                 }
             }
 
-            File.Delete(outpath);
+            File.Delete (outpath);
             return result;
         }
 
@@ -746,15 +659,12 @@ namespace NugetUtility
         /// </summary>
         /// <param name="libraries">List<LibraryInfo></param>
         /// <returns>A List of LibraryInfo</returns>
-        public List<LibraryInfo> HandleDeprecateMSFTLicense(List<LibraryInfo> libraries)
-        {
+        public List<LibraryInfo> HandleDeprecateMSFTLicense (List<LibraryInfo> libraries) {
             List<LibraryInfo> result = libraries;
 
-            foreach (var item in result)
-            {
-                if (item.LicenseUrl == deprecateNugetLicense)
-                {
-                    item.LicenseUrl = string.Format("https://www.nuget.org/packages/{0}/{1}/License", item.PackageName, item.PackageVersion);
+            foreach (var item in result) {
+                if (item.LicenseUrl == deprecateNugetLicense) {
+                    item.LicenseUrl = string.Format ("https://www.nuget.org/packages/{0}/{1}/License", item.PackageName, item.PackageVersion);
                 }
             }
             return result;
@@ -764,66 +674,57 @@ namespace NugetUtility
             var directory = GetExportDirectory ();
             foreach (var info in infos.Where (i => !string.IsNullOrEmpty (i.LicenseUrl))) {
                 var source = info.LicenseUrl;
-                var outpath = Path.Combine(directory, $"{info.PackageName}_{info.PackageVersion}.txt");
-                if (File.Exists(outpath))
-                {
+                var outpath = Path.Combine (directory, $"{info.PackageName}_{info.PackageVersion}.txt");
+                if (File.Exists (outpath)) {
                     continue;
                 }
-                if (source == deprecateNugetLicense)
-                {
-                    if (await GetLicenceFromNpkgFile(info.PackageName, info.LicenseType, info.PackageVersion))
+                if (source == deprecateNugetLicense) {
+                    if (await GetLicenceFromNpkgFile (info.PackageName, info.LicenseType, info.PackageVersion))
                         continue;
                 }
 
-                if (source == "http://go.microsoft.com/fwlink/?LinkId=329770" || source == "https://dotnet.microsoft.com/en/dotnet_library_license.htm")
-                {
-                    if (await GetLicenceFromNpkgFile(info.PackageName, "dotnet_library_license.txt", info.PackageVersion))
+                if (source == "http://go.microsoft.com/fwlink/?LinkId=329770" || source == "https://dotnet.microsoft.com/en/dotnet_library_license.htm") {
+                    if (await GetLicenceFromNpkgFile (info.PackageName, "dotnet_library_license.txt", info.PackageVersion))
                         continue;
                 }
 
-                if (source.StartsWith("https://licenses.nuget.org"))
-                {
-                    if (await GetLicenceFromNpkgFile(info.PackageName, "License.txt", info.PackageVersion))
+                if (source.StartsWith ("https://licenses.nuget.org")) {
+                    if (await GetLicenceFromNpkgFile (info.PackageName, "License.txt", info.PackageVersion))
                         continue;
                 }
 
-                do
-                {
-                    WriteOutput(() => $"Attempting to download {source} to {outpath}", logLevel: LogLevel.Verbose);
-                    using var request = new HttpRequestMessage(HttpMethod.Get, source);
-                    using var response = await _httpClient.SendAsync(request);
-                    if (!response.IsSuccessStatusCode)
-                    {
-                        WriteOutput($"{request.RequestUri} failed due to {response.StatusCode}!", logLevel: LogLevel.Error);
+                do {
+                    WriteOutput (() => $"Attempting to download {source} to {outpath}", logLevel : LogLevel.Verbose);
+                    using var request = new HttpRequestMessage (HttpMethod.Get, source);
+                    using var response = await _httpClient.SendAsync (request);
+                    if (!response.IsSuccessStatusCode) {
+                        WriteOutput ($"{request.RequestUri} failed due to {response.StatusCode}!", logLevel : LogLevel.Error);
                         break;
                     }
 
                     // Detect a redirect 302
-                    if (response.RequestMessage.RequestUri.AbsoluteUri != source)
-                    {
-                        WriteOutput(() => " Redirect detected", logLevel: LogLevel.Verbose);
+                    if (response.RequestMessage.RequestUri.AbsoluteUri != source) {
+                        WriteOutput (() => " Redirect detected", logLevel : LogLevel.Verbose);
                         source = response.RequestMessage.RequestUri.AbsoluteUri;
                         continue;
                     }
 
                     // Modify the URL if required
-                    if (CorrectUri(source) != source)
-                    {
-                        WriteOutput(() => " Fixing URL", logLevel: LogLevel.Verbose);
-                        source = CorrectUri(source);
+                    if (CorrectUri (source) != source) {
+                        WriteOutput (() => " Fixing URL", logLevel : LogLevel.Verbose);
+                        source = CorrectUri (source);
                         continue;
                     }
 
-                    using var fileStream = File.OpenWrite(outpath);
-                    await response.Content.CopyToAsync(fileStream);
+                    using var fileStream = File.OpenWrite (outpath);
+                    await response.Content.CopyToAsync (fileStream);
                     break;
                 } while (true);
             }
         }
 
-        private bool IsGithub(string uri)
-        {
-            return uri.StartsWith("https://github.com", StringComparison.Ordinal);
+        private bool IsGithub (string uri) {
+            return uri.StartsWith ("https://github.com", StringComparison.Ordinal);
         }
 
         /// <summary>
@@ -831,106 +732,94 @@ namespace NugetUtility
         /// </summary>
         /// <param name="uri">URI</param>
         /// <returns>Returns the raw URL to get the raw text of the library</returns>
-        private string CorrectUri(string uri)
-        {
-            if (!IsGithub(uri))
-            {
+        private string CorrectUri (string uri) {
+            if (!IsGithub (uri)) {
                 return uri;
             }
 
-            if (uri.Contains("/blob/", StringComparison.Ordinal))
-            {
-                uri = uri.Replace("/blob/", "/raw/", StringComparison.Ordinal);
+            if (uri.Contains ("/blob/", StringComparison.Ordinal)) {
+                uri = uri.Replace ("/blob/", "/raw/", StringComparison.Ordinal);
             }
 
-          /*  if (uri.Contains("/dotnet/corefx/", StringComparison.Ordinal))
-            {
-                uri = uri.Replace("/dotnet/corefx/", "/dotnet/runtime/", StringComparison.Ordinal);
-            }*/
+            /*  if (uri.Contains("/dotnet/corefx/", StringComparison.Ordinal))
+              {
+                  uri = uri.Replace("/dotnet/corefx/", "/dotnet/runtime/", StringComparison.Ordinal);
+              }*/
 
             return uri;
         }
 
-        public void PrintLicenses(List<LibraryInfo> libraries)
-        {
-            if (libraries is null) { throw new ArgumentNullException(nameof(libraries)); }
-            if (!libraries.Any()) { return; }
+        public void PrintLicenses (List<LibraryInfo> libraries) {
+            if (libraries is null) { throw new ArgumentNullException (nameof (libraries)); }
+            if (!libraries.Any ()) { return; }
 
-            WriteOutput(Environment.NewLine + "References:", logLevel: LogLevel.Always);
-            WriteOutput(libraries.ToStringTable(new[] { "Reference", "Version", "License Type", "License" },
-                                                            a => a.PackageName ?? "---",
-                                                            a => a.PackageVersion ?? "---",
-                                                            a => a.LicenseType ?? "---",
-                                                            a => a.LicenseUrl ?? "---"), logLevel: LogLevel.Always);
+            WriteOutput (Environment.NewLine + "References:", logLevel : LogLevel.Always);
+            WriteOutput (libraries.ToStringTable (new [] { "Reference", "Version", "License Type", "License" },
+                a => a.PackageName ?? "---",
+                a => a.PackageVersion ?? "---",
+                a => a.LicenseType ?? "---",
+                a => a.LicenseUrl ?? "---"), logLevel : LogLevel.Always);
         }
 
-        public void SaveAsJson(List<LibraryInfo> libraries)
-        {
-            if (!libraries.Any() || !_packageOptions.JsonOutput) { return; }
-            JsonSerializerSettings jsonSettings = new JsonSerializerSettings
-            {
+        public void SaveAsJson (List<LibraryInfo> libraries) {
+            if (!libraries.Any () || !_packageOptions.JsonOutput) { return; }
+            JsonSerializerSettings jsonSettings = new JsonSerializerSettings {
                 NullValueHandling = _packageOptions.IncludeProjectFile ? NullValueHandling.Include : NullValueHandling.Ignore
             };
 
-            using var fileStream = new FileStream(GetOutputFilename("licenses.json"), FileMode.Create);
-            using var streamWriter = new StreamWriter(fileStream);
-            streamWriter.Write(JsonConvert.SerializeObject(libraries, jsonSettings));
-            streamWriter.Flush();
+            using var fileStream = new FileStream (GetOutputFilename ("licenses.json"), FileMode.Create);
+            using var streamWriter = new StreamWriter (fileStream);
+            streamWriter.Write (JsonConvert.SerializeObject (libraries, jsonSettings));
+            streamWriter.Flush ();
         }
 
-        public void SaveAsTextFile(List<LibraryInfo> libraries)
-        {
-            if (!libraries.Any() || !_packageOptions.TextOutput) { return; }
-            StringBuilder sb = new StringBuilder(256);
-            foreach (var lib in libraries)
-            {
-                sb.Append(new string('#', 100));
-                sb.AppendLine();
-                sb.Append("Package:");
-                sb.Append(lib.PackageName);
-                sb.AppendLine();
-                sb.Append("Version:");
-                sb.Append(lib.PackageVersion);
-                sb.AppendLine();
-                sb.Append("project URL:");
-                sb.Append(lib.PackageUrl);
-                sb.AppendLine();
-                sb.Append("Description:");
-                sb.Append(lib.Description);
-                sb.AppendLine();
-                sb.Append("licenseUrl:");
-                sb.Append(lib.LicenseUrl);
-                sb.AppendLine();
-                sb.Append("license Type:");
-                sb.Append(lib.LicenseType);
-                sb.AppendLine();
-                if (_packageOptions.IncludeProjectFile)
-                {
-                    sb.Append("Project:");
-                    sb.Append(lib.Projects);
-                    sb.AppendLine();
+        public void SaveAsTextFile (List<LibraryInfo> libraries) {
+            if (!libraries.Any () || !_packageOptions.TextOutput) { return; }
+            StringBuilder sb = new StringBuilder (256);
+            foreach (var lib in libraries) {
+                sb.Append (new string ('#', 100));
+                sb.AppendLine ();
+                sb.Append ("Package:");
+                sb.Append (lib.PackageName);
+                sb.AppendLine ();
+                sb.Append ("Version:");
+                sb.Append (lib.PackageVersion);
+                sb.AppendLine ();
+                sb.Append ("project URL:");
+                sb.Append (lib.PackageUrl);
+                sb.AppendLine ();
+                sb.Append ("Description:");
+                sb.Append (lib.Description);
+                sb.AppendLine ();
+                sb.Append ("licenseUrl:");
+                sb.Append (lib.LicenseUrl);
+                sb.AppendLine ();
+                sb.Append ("license Type:");
+                sb.Append (lib.LicenseType);
+                sb.AppendLine ();
+                if (_packageOptions.IncludeProjectFile) {
+                    sb.Append ("Project:");
+                    sb.Append (lib.Projects);
+                    sb.AppendLine ();
                 }
-                sb.AppendLine();
+                sb.AppendLine ();
             }
 
-            File.WriteAllText(GetOutputFilename("licenses.txt"), sb.ToString());
+            File.WriteAllText (GetOutputFilename ("licenses.txt"), sb.ToString ());
         }
 
-        private void WriteOutput(Func<string> line, Exception exception = null, LogLevel logLevel = LogLevel.Information)
-        {
-            if ((int)logLevel < (int)_packageOptions.LogLevelThreshold)
-            {
+        private void WriteOutput (Func<string> line, Exception exception = null, LogLevel logLevel = LogLevel.Information) {
+            if ((int) logLevel < (int) _packageOptions.LogLevelThreshold) {
                 return;
             }
 
-            Console.WriteLine(line.Invoke());
+            Console.WriteLine (line.Invoke ());
 
-            if (exception is object)
-            {
-                Console.WriteLine(exception.ToString());
+            if (exception is object) {
+                Console.WriteLine (exception.ToString ());
             }
         }
 
-        private void WriteOutput(string line, Exception exception = null, LogLevel logLevel = LogLevel.Information) => WriteOutput(() => line, exception, logLevel);
+        private void WriteOutput (string line, Exception exception = null, LogLevel logLevel = LogLevel.Information) => WriteOutput (() => line, exception, logLevel);
     }
 }

--- a/src/PackageOptions.cs
+++ b/src/PackageOptions.cs
@@ -50,10 +50,10 @@ namespace NugetUtility {
         [Option ("packages-filter", Default = null, HelpText = "Simple json file of a text array of packages to skip, or a regular expression defined between two forward slashes.")]
         public string PackagesFilterOption { get; set; }
 
-        [Option ('u', "unique", Default = false, HelpText = "Unique licenses list by Id/Version")]
+        [Option ('u', "unique", Default = false, HelpText = "Unique licenses list by Package Name(Id)/Version")]
         public bool UniqueOnly { get; set; }
 
-        [Option ("unique-by-package-name", Default = false, HelpText = "Unique licenses list by Name")]
+        [Option ("unique-by-package-name", Default = false, HelpText = "Unique licenses list only by Package Name (Id)")]
         public bool UniqueByPackageName { get; set; }
 
         [Option ('p', "print", Default = true, HelpText = "Print licenses.")]

--- a/src/PackageOptions.cs
+++ b/src/PackageOptions.cs
@@ -7,145 +7,138 @@ using CommandLine;
 using CommandLine.Text;
 using static NugetUtility.Utilties;
 
-namespace NugetUtility
-{
-    public class PackageOptions
-    {
-        private readonly Regex UserRegexRegex = new Regex("^\\/(.+)\\/$");
+namespace NugetUtility {
+    public class PackageOptions {
+        private readonly Regex UserRegexRegex = new Regex ("^\\/(.+)\\/$");
 
-        private ICollection<string> _allowedLicenseTypes = new Collection<string>();
-        private ICollection<LibraryInfo> _manualInformation = new Collection<LibraryInfo>();
-        private ICollection<string> _projectFilter = new Collection<string>();
-        private ICollection<string> _packagesFilter = new Collection<string>();
-        private Dictionary<string, string> _customLicenseToUrlMappings = new Dictionary<string, string>();
+        private ICollection<string> _allowedLicenseTypes = new Collection<string> ();
+        private ICollection<LibraryInfo> _manualInformation = new Collection<LibraryInfo> ();
+        private ICollection<string> _projectFilter = new Collection<string> ();
+        private ICollection<string> _packagesFilter = new Collection<string> ();
+        private Dictionary<string, string> _customLicenseToUrlMappings = new Dictionary<string, string> ();
 
-        [Option("allowed-license-types", Default = null, HelpText = "Simple json file of a text array of allowable licenses, if no file is given, all are assumed allowed")]
+        [Option ("allowed-license-types", Default = null, HelpText = "Simple json file of a text array of allowable licenses, if no file is given, all are assumed allowed")]
         public string AllowedLicenseTypesOption { get; set; }
 
-        [Option("include-project-file", Default = false, HelpText = "Adds project file path to information when enabled.")]
+        [Option ("include-project-file", Default = false, HelpText = "Adds project file path to information when enabled.")]
         public bool IncludeProjectFile { get; set; }
 
-        [Option('l', "log-level", Default = LogLevel.Error, HelpText = "Sets log level for output display. Options: Error|Warning|Information|Verbose.")]
+        [Option ('l', "log-level", Default = LogLevel.Error, HelpText = "Sets log level for output display. Options: Error|Warning|Information|Verbose.")]
         public LogLevel LogLevelThreshold { get; set; }
 
-        [Option("manual-package-information", Default = null, HelpText = "Simple json file of an array of LibraryInfo objects for manually determined packages.")]
+        [Option ("manual-package-information", Default = null, HelpText = "Simple json file of an array of LibraryInfo objects for manually determined packages.")]
         public string ManualInformationOption { get; set; }
 
-        [Option("licenseurl-to-license-mappings", Default = null, HelpText = "Simple json file of Dictinary<string,string> to override default mappings")]
+        [Option ("licenseurl-to-license-mappings", Default = null, HelpText = "Simple json file of Dictinary<string,string> to override default mappings")]
         public string LicenseToUrlMappingsOption { get; set; }
 
-        [Option('o', "output", Default = false, HelpText = "Saves as text file (licenses.txt)")]
+        [Option ('o', "output", Default = false, HelpText = "Saves as text file (licenses.txt)")]
         public bool TextOutput { get; set; }
 
-        [Option("outfile", Default = null, HelpText = "Output filename")]
+        [Option ("outfile", Default = null, HelpText = "Output filename")]
         public string OutputFileName { get; set; }
 
-        [Option('f', "output-directory", Default = null, HelpText = "Output Directory")]
+        [Option ('f', "output-directory", Default = null, HelpText = "Output Directory")]
         public string OutputDirectory { get; set; }
 
-        [Option('i', "input", HelpText = "The projects in which to search for used nuget packages. This can either be a folder, a project file, a solution file or a json file containing a list of projects.")]
+        [Option ('i', "input", HelpText = "The projects in which to search for used nuget packages. This can either be a folder, a project file, a solution file or a json file containing a list of projects.")]
         public string ProjectDirectory { get; set; }
 
-        [Option("projects-filter", Default = null, HelpText = "Simple json file of a text array of projects to skip. Supports Ends with matching such as 'Tests.csproj'")]
+        [Option ("projects-filter", Default = null, HelpText = "Simple json file of a text array of projects to skip. Supports Ends with matching such as 'Tests.csproj'")]
         public string ProjectsFilterOption { get; set; }
 
-        [Option("packages-filter", Default = null, HelpText = "Simple json file of a text array of packages to skip, or a regular expression defined between two forward slashes.")]
+        [Option ("packages-filter", Default = null, HelpText = "Simple json file of a text array of packages to skip, or a regular expression defined between two forward slashes.")]
         public string PackagesFilterOption { get; set; }
 
-        [Option('u', "unique", Default = false, HelpText = "Unique licenses list by Id/Version")]
+        [Option ('u', "unique", Default = false, HelpText = "Unique licenses list by Id/Version")]
         public bool UniqueOnly { get; set; }
 
-        [Option('p', "print", Default = true, HelpText = "Print licenses.")]
+        [Option ("unique-by-package-name", Default = false, HelpText = "Unique licenses list by Name")]
+        public bool UniqueByPackageName { get; set; }
+
+        [Option ('p', "print", Default = true, HelpText = "Print licenses.")]
         public bool? Print { get; set; }
 
-        [Option('j', "json", Default = false, HelpText = "Saves licenses list in a json file (licenses.json)")]
+        [Option ('j', "json", Default = false, HelpText = "Saves licenses list in a json file (licenses.json)")]
         public bool JsonOutput { get; set; }
 
-        [Option('e', "export-license-texts", Default = false, HelpText = "Exports the raw license texts")]
+        [Option ('e', "export-license-texts", Default = false, HelpText = "Exports the raw license texts")]
         public bool ExportLicenseTexts { get; set; }
 
-        [Option('t', "include-transitive", Default = false, HelpText = "Include distinct transitive package licenses per project file.")]
+        [Option ('t', "include-transitive", Default = false, HelpText = "Include distinct transitive package licenses per project file.")]
         public bool IncludeTransitive { get; set; }
 
-        [Option("ignore-ssl-certificate-errors", Default = false, HelpText = "Ignore SSL certificate errors in HttpClient.")]
+        [Option ("ignore-ssl-certificate-errors", Default = false, HelpText = "Ignore SSL certificate errors in HttpClient.")]
         public bool IgnoreSslCertificateErrors { get; set; }
 
-        [Usage(ApplicationAlias = "dotnet-project-licenses")]
-        public static IEnumerable<Example> Examples
-        {
-            get
-            {
-                return new List<Example>() {
+        [Usage (ApplicationAlias = "dotnet-project-licenses")]
+        public static IEnumerable<Example> Examples {
+            get {
+            return new List<Example> () {
             new Example ("Simple", new PackageOptions { ProjectDirectory = "~/Projects/test-project" }),
             new Example ("VS Solution", new PackageOptions { ProjectDirectory = "~/Projects/test-project/project.sln" }),
             new Example ("Unique VS Solution to Custom JSON File", new PackageOptions {
-                        ProjectDirectory = "~/Projects/test-project/project.sln",
-                        UniqueOnly = true,
-                        JsonOutput = true,
-                        OutputFileName = @"~/Projects/another-folder/licenses.json"
-                        }),
-            new Example("Export all license texts in a specific directory with verbose log", new PackageOptions
-            {
-                LogLevelThreshold = LogLevel.Verbose,
-                OutputDirectory = "~/Projects/exports",
-                ExportLicenseTexts = true,
+            ProjectDirectory = "~/Projects/test-project/project.sln",
+            UniqueOnly = true,
+            JsonOutput = true,
+            OutputFileName = @"~/Projects/another-folder/licenses.json"
+            }),
+            new Example ("Unique By Package Name VS Solution to Custom JSON File", new PackageOptions {
+            ProjectDirectory = "~/Projects/test-project/project.sln",
+            UniqueByPackageName = true,
+            JsonOutput = true,
+            OutputFileName = @"~/Projects/another-folder/licenses.json"
+            }),
+            new Example ("Export all license texts in a specific directory with verbose log", new PackageOptions {
+            LogLevelThreshold = LogLevel.Verbose,
+            OutputDirectory = "~/Projects/exports",
+            ExportLicenseTexts = true,
             }),
                 };
             }
         }
 
-        public ICollection<string> AllowedLicenseType
-        {
-            get
-            {
-                if (_allowedLicenseTypes.Any()) { return _allowedLicenseTypes; }
+        public ICollection<string> AllowedLicenseType {
+            get {
+                if (_allowedLicenseTypes.Any ()) { return _allowedLicenseTypes; }
 
-                return _allowedLicenseTypes = ReadListFromFile<string>(AllowedLicenseTypesOption);
+                return _allowedLicenseTypes = ReadListFromFile<string> (AllowedLicenseTypesOption);
             }
         }
 
-        public ICollection<LibraryInfo> ManualInformation
-        {
-            get
-            {
-                if (_manualInformation.Any()) { return _manualInformation; }
+        public ICollection<LibraryInfo> ManualInformation {
+            get {
+                if (_manualInformation.Any ()) { return _manualInformation; }
 
-                return _manualInformation = ReadListFromFile<LibraryInfo>(ManualInformationOption);
+                return _manualInformation = ReadListFromFile<LibraryInfo> (ManualInformationOption);
             }
         }
 
-        public ICollection<string> ProjectFilter
-        {
-            get
-            {
-                if (_projectFilter.Any()) { return _projectFilter; }
+        public ICollection<string> ProjectFilter {
+            get {
+                if (_projectFilter.Any ()) { return _projectFilter; }
 
-                return _projectFilter = ReadListFromFile<string>(ProjectsFilterOption)
-                    .Select(x => x.EnsureCorrectPathCharacter())
-                    .ToList();
+                return _projectFilter = ReadListFromFile<string> (ProjectsFilterOption)
+                    .Select (x => x.EnsureCorrectPathCharacter ())
+                    .ToList ();
             }
         }
 
-        public Regex? PackageRegex
-        {
-            get
-            {
+        public Regex? PackageRegex {
+            get {
                 if (PackagesFilterOption == null) return null;
 
                 // Check if the input is a regular expression that is defined between two forward slashes '/';
-                if (UserRegexRegex.IsMatch(PackagesFilterOption))
-                {
-                    var userRegexString = UserRegexRegex.Replace(PackagesFilterOption, "$1");
+                if (UserRegexRegex.IsMatch (PackagesFilterOption)) {
+                    var userRegexString = UserRegexRegex.Replace (PackagesFilterOption, "$1");
                     // Try parse regular expression between forward slashes
-                    try
-                    {
-                        var parsedExpression = new Regex(userRegexString, RegexOptions.IgnoreCase);
+                    try {
+                        var parsedExpression = new Regex (userRegexString, RegexOptions.IgnoreCase);
                         return parsedExpression;
                     }
                     // Catch and suppress Argument exception thrown when pattern is invalid
-                    catch (ArgumentException e)
-                    {
-                        throw new ArgumentException($"Cannot parse regex '{userRegexString}'", e);
+                    catch (ArgumentException e) {
+                        throw new ArgumentException ($"Cannot parse regex '{userRegexString}'", e);
                     }
                 }
 
@@ -153,29 +146,24 @@ namespace NugetUtility
             }
         }
 
-        public ICollection<string> PackageFilter
-        {
-            get
-            {
+        public ICollection<string> PackageFilter {
+            get {
                 // If we've already found package filters, or the user input is a regular expression,
                 // Return the packagesFilter
-                if (_packagesFilter.Any() ||
-                    (PackagesFilterOption != null && UserRegexRegex.IsMatch(PackagesFilterOption)))
-                {
+                if (_packagesFilter.Any () ||
+                    (PackagesFilterOption != null && UserRegexRegex.IsMatch (PackagesFilterOption))) {
                     return _packagesFilter;
                 }
 
-                return _packagesFilter = ReadListFromFile<string>(PackagesFilterOption);
+                return _packagesFilter = ReadListFromFile<string> (PackagesFilterOption);
             }
         }
 
-        public IReadOnlyDictionary<string, string> LicenseToUrlMappingsDictionary
-        {
-            get
-            {
-                if (_customLicenseToUrlMappings.Any()) { return _customLicenseToUrlMappings; }
+        public IReadOnlyDictionary<string, string> LicenseToUrlMappingsDictionary {
+            get {
+                if (_customLicenseToUrlMappings.Any ()) { return _customLicenseToUrlMappings; }
 
-                return _customLicenseToUrlMappings = ReadDictionaryFromFile(LicenseToUrlMappingsOption, LicenseToUrlMappings.Default);
+                return _customLicenseToUrlMappings = ReadDictionaryFromFile (LicenseToUrlMappingsOption, LicenseToUrlMappings.Default);
             }
         }
     }

--- a/tests/NugetUtility.Tests/MethodsTests.cs
+++ b/tests/NugetUtility.Tests/MethodsTests.cs
@@ -124,7 +124,7 @@ namespace NugetUtility.Tests {
             var packages = new Dictionary<string, PackageList> ();
             packages.Add ("packages", list);
             var info = _methods.MapPackagesToLibraryInfo (packages);
-            info.Count.Should ().Equals (1);
+            info.Count.Should ().Be (2);
         }
 
         [Test]
@@ -167,7 +167,7 @@ namespace NugetUtility.Tests {
             var packages = new Dictionary<string, PackageList> ();
             packages.Add ("packages", list);
             var info = _methods.MapPackagesToLibraryInfo (packages);
-            info.Count.Should ().Equals (1);
+            info.Count.Should ().Be (1);
         }
 
         [Test]

--- a/tests/NugetUtility.Tests/MethodsTests.cs
+++ b/tests/NugetUtility.Tests/MethodsTests.cs
@@ -23,6 +23,10 @@ namespace NugetUtility.Tests {
             _methods = new Methods (new PackageOptions { UniqueOnly = true, ProjectDirectory = _projectPath });
         }
 
+        private void AddUniquePackageNameOption () {
+            _methods = new Methods (new PackageOptions { UniqueByPackageName = true, ProjectDirectory = _projectPath });
+        }
+
         [Test]
         public void GetProjectExtension_Should_Be_CsprojOrFsProj () {
             _methods.GetProjectExtensions ().Should ().Contain (".csproj", ".fsproj");
@@ -106,6 +110,60 @@ namespace NugetUtility.Tests {
                 }
             });
 
+            list.Add ("log4net3", new Package {
+                Metadata = new Metadata {
+                    Id = "log4net",
+                        License = new License {
+                            Text = "MIT",
+                                Type = "Open"
+                        },
+                        Version = "2.1.0",
+                },
+            });
+
+            var packages = new Dictionary<string, PackageList> ();
+            packages.Add ("packages", list);
+            var info = _methods.MapPackagesToLibraryInfo (packages);
+            info.Count.Should ().Equals (1);
+        }
+
+        [Test]
+        public void MapPackagesToLibraryInfo_UniquePackageNames_Should_Return_One_Result () {
+            AddUniquePackageNameOption ();
+            PackageList list = new PackageList ();
+            list.Add ("log4net", new Package {
+                Metadata = new Metadata {
+                    Id = "log4net",
+                        License = new License {
+                            Text = "MIT",
+                                Type = "Open"
+                        },
+                        Version = "2.0.8",
+                },
+            });
+
+            list.Add ("log4net2", new Package {
+                Metadata = new Metadata {
+                    Id = "log4net",
+                        License = new License {
+                            Text = "MIT",
+                                Type = "Open"
+                        },
+                        Version = "2.0.8",
+                }
+            });
+
+            list.Add ("log4net3", new Package {
+                Metadata = new Metadata {
+                    Id = "log4net",
+                        License = new License {
+                            Text = "MIT",
+                                Type = "Open"
+                        },
+                        Version = "2.1.0",
+                },
+            });
+
             var packages = new Dictionary<string, PackageList> ();
             packages.Add ("packages", list);
             var info = _methods.MapPackagesToLibraryInfo (packages);
@@ -140,18 +198,16 @@ namespace NugetUtility.Tests {
         }
 
         [Test]
-        public async Task GetPackages_RegexPackagesFilter_Should_Remove_CommandLineParser()
-        {
-            var methods = new Methods(new PackageOptions
-            {
+        public async Task GetPackages_RegexPackagesFilter_Should_Remove_CommandLineParser () {
+            var methods = new Methods (new PackageOptions {
                 PackagesFilterOption = "/CommandLine*/",
-                ProjectDirectory = TestSetup.ThisProjectSolutionPath
+                    ProjectDirectory = TestSetup.ThisProjectSolutionPath
             });
 
-            var result = await methods.GetPackages();
+            var result = await methods.GetPackages ();
 
-            result.Should().NotBeEmpty()
-                .And.NotContainKey("CommandLineParser");
+            result.Should ().NotBeEmpty ()
+                .And.NotContainKey ("CommandLineParser");
         }
 
         [Test]
@@ -185,61 +241,53 @@ namespace NugetUtility.Tests {
             validationResult.InvalidPackages.Count.Should ().Be (3);
         }
 
-
-        [TestCase("BenchmarkDotNet", "0.12.1", "https://licenses.nuget.org/MIT", "MIT")]
-        [TestCase("BCrypt.Net-Next", "2.1.3", "https://github.com/BcryptNet/bcrypt.net/blob/master/licence.txt", "")]
-        [TestCase("System.Memory", "4.5.4", "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT", "MIT")]
-        [TestCase("System.Text.RegularExpressions", "4.3.0", "http://go.microsoft.com/fwlink/?LinkId=329770", "MS-EULA")]
+        [TestCase ("BenchmarkDotNet", "0.12.1", "https://licenses.nuget.org/MIT", "MIT")]
+        [TestCase ("BCrypt.Net-Next", "2.1.3", "https://github.com/BcryptNet/bcrypt.net/blob/master/licence.txt", "")]
+        [TestCase ("System.Memory", "4.5.4", "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT", "MIT")]
+        [TestCase ("System.Text.RegularExpressions", "4.3.0", "http://go.microsoft.com/fwlink/?LinkId=329770", "MS-EULA")]
         [Test]
-        public async Task ExportLicenseTexts_Should_Export_File(string packageName, string packageVersion, string licenseUrl, string licenseType)
-        {
-            var methods = new Methods(new PackageOptions
-            {
+        public async Task ExportLicenseTexts_Should_Export_File (string packageName, string packageVersion, string licenseUrl, string licenseType) {
+            var methods = new Methods (new PackageOptions {
                 ExportLicenseTexts = true,
             });
-            List<LibraryInfo> infos = new List<LibraryInfo>();
-            infos.Add(new LibraryInfo()
-            {
+            List<LibraryInfo> infos = new List<LibraryInfo> ();
+            infos.Add (new LibraryInfo () {
                 PackageName = packageName,
-                PackageVersion = packageVersion,
-                LicenseUrl = licenseUrl,
-                LicenseType = licenseType,
+                    PackageVersion = packageVersion,
+                    LicenseUrl = licenseUrl,
+                    LicenseType = licenseType,
             });
-            await methods.ExportLicenseTexts(infos);
-            var directory = methods.GetExportDirectory();
-            var outpath = Path.Combine(directory, packageName + "_" + packageVersion + ".txt");
-            Assert.That(File.Exists(outpath));
+            await methods.ExportLicenseTexts (infos);
+            var directory = methods.GetExportDirectory ();
+            var outpath = Path.Combine (directory, packageName + "_" + packageVersion + ".txt");
+            Assert.That (File.Exists (outpath));
         }
 
-        [TestCase("BenchmarkDotNet", "License.txt", "10.12.1")]
+        [TestCase ("BenchmarkDotNet", "License.txt", "10.12.1")]
         [Test]
-        public async Task GetLicenceFromNpkgFile_Should_Return_False(string packageName, string licenseFile, string packageVersion)
-        {
-            var methods = new Methods(new PackageOptions
-            {
+        public async Task GetLicenceFromNpkgFile_Should_Return_False (string packageName, string licenseFile, string packageVersion) {
+            var methods = new Methods (new PackageOptions {
                 ExportLicenseTexts = true,
             });
 
-            var result = await methods.GetLicenceFromNpkgFile(packageName, licenseFile, packageVersion);
-            Assert.False(result);
+            var result = await methods.GetLicenceFromNpkgFile (packageName, licenseFile, packageVersion);
+            Assert.False (result);
         }
 
         [Test]
-        public void HttpClient_IgnoreSslError_CallbackTest()
-        {
-            Assert.True(Methods.IgnoreSslCertificateErrorCallback(null, null, null, System.Net.Security.SslPolicyErrors.None));
+        public void HttpClient_IgnoreSslError_CallbackTest () {
+            Assert.True (Methods.IgnoreSslCertificateErrorCallback (null, null, null, System.Net.Security.SslPolicyErrors.None));
         }
 
-        [TestCase("System.Linq", "(4.1.0,)")]
-        [TestCase("BCrypt.Net-Next", "2.1.3")]
+        [TestCase ("System.Linq", "(4.1.0,)")]
+        [TestCase ("BCrypt.Net-Next", "2.1.3")]
         [Test]
-        public void HttpClient_IgnoreSslError_GetNugetInformationAsync(string package, string version)
-        {
-            var methods = new Methods(new PackageOptions { ProjectDirectory = _projectPath, IgnoreSslCertificateErrors = true });
+        public void HttpClient_IgnoreSslError_GetNugetInformationAsync (string package, string version) {
+            var methods = new Methods (new PackageOptions { ProjectDirectory = _projectPath, IgnoreSslCertificateErrors = true });
 
             var referencedpackages = new PackageNameAndVersion[] { new PackageNameAndVersion { Name = package, Version = version } };
 
-            Assert.DoesNotThrowAsync(async () => await _methods.GetNugetInformationAsync(_projectPath, referencedpackages));
+            Assert.DoesNotThrowAsync (async () => await _methods.GetNugetInformationAsync (_projectPath, referencedpackages));
         }
     }
 }

--- a/tests/NugetUtility.Tests/PackageOptionsTests.cs
+++ b/tests/NugetUtility.Tests/PackageOptionsTests.cs
@@ -1,61 +1,57 @@
-﻿using FluentAssertions;
-using Newtonsoft.Json;
-using NUnit.Framework;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
 
-namespace NugetUtility.Tests
-{
+namespace NugetUtility.Tests {
     [TestFixture]
-    public class PackageOptionsTests
-    {
+    public class PackageOptionsTests {
         [Test]
-        public void LicenseToUrlMappingsOption_When_Set_Should_Replace_Default_Mappings()
-        {
-            var testMappings = new Dictionary<string, string>
-            {
-                {"url1","license1" },
-                {"url2","license1" },
-            };
+        public void LicenseToUrlMappingsOption_When_Set_Should_Replace_Default_Mappings () {
+            var testMappings = new Dictionary<string, string> { { "url1", "license1" },
+                    { "url2", "license1" },
+                };
             var testFile = "test-mappings.json";
-            File.WriteAllText(testFile, JsonConvert.SerializeObject(testMappings));
+            File.WriteAllText (testFile, JsonConvert.SerializeObject (testMappings));
 
             var options = new PackageOptions { LicenseToUrlMappingsOption = testFile };
 
-            options.LicenseToUrlMappingsDictionary.Should().HaveCount(2)
-                .And.BeEquivalentTo(testMappings);
+            options.LicenseToUrlMappingsDictionary.Should ().HaveCount (2)
+                .And.BeEquivalentTo (testMappings);
         }
 
-
         [Test]
-        public void UniqueMappingsOption_When_Set_Should_Replace_Default_Mappings()
-        {
+        public void UniqueMappingsOption_When_Set_Should_Replace_Default_Mappings () {
             var options = new PackageOptions { UniqueOnly = true };
-            
-            options.UniqueOnly.Should().BeTrue();
+
+            options.UniqueOnly.Should ().BeTrue ();
         }
 
         [Test]
-        public void PackagesFilterOption_IncorrectRegexPackagesFilter_Should_Throw_ArgumentException()
-        {
-            var options = new PackageOptions
-            {
+        public void UniqueByPackageNameOption_When_Set_Should_Replice_Default_Mappings () {
+            var options = new PackageOptions { UniqueByPackageName = true };
+            options.UniqueByPackageName.Should ().BeTrue ();
+        }
+
+        [Test]
+        public void PackagesFilterOption_IncorrectRegexPackagesFilter_Should_Throw_ArgumentException () {
+            var options = new PackageOptions {
                 PackagesFilterOption = "/(?/",
             };
 
-            Assert.Throws(typeof(ArgumentException), () => { var regex = options.PackageRegex; });
+            Assert.Throws (typeof (ArgumentException), () => { var regex = options.PackageRegex; });
         }
 
         [Test]
         public void PackagesFilterOption_IncorrectPackagesFilterPath_Should_Throw_FileNotFoundException () {
-            
-            var options = new PackageOptions
-            {
+
+            var options = new PackageOptions {
                 PackagesFilterOption = @"../../../DoesNotExist.json",
             };
 
-            Assert.Throws(typeof(FileNotFoundException), () => { var regex = options.PackageFilter; });
+            Assert.Throws (typeof (FileNotFoundException), () => { var regex = options.PackageFilter; });
         }
     }
 }


### PR DESCRIPTION
This PR introduces a new option, the `unique-by-package-name`.
This option group the licenses only by name. 
This option differs from `unique` option which groups the licenses by name and version. 