### PR TITLE
Added --use-project-assets-json

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Usage: dotnet-project-licenses [options]
 | `--help` | Display this help screen. |
 | `--version` | Display version information. |
 | `--ignore-ssl-certificate-errors` | Ignores SSL certificate errors in HttpClient. |
+| `--use-project-assets-json` | Use the resolved project.assets.json file for each project as the source of package information. Requires the `-t` option since this always includes transitive references. Requires `nuget restore` or `dotnet restore` to be run first. |
 
 ## Example tool commands
 

--- a/src/Methods.cs
+++ b/src/Methods.cs
@@ -278,9 +278,11 @@ namespace NugetUtility
                 throw new FileNotFoundException();
             }
 
+            IEnumerable<string> references = Array.Empty<string>();
+         
+            // First use project.assets.json, if this option is enabled.
             if (_packageOptions.UseProjectAssetsJson)
             {
-                // Use only project.assets.json.
                 var assetsFile = Path.Combine(Path.GetDirectoryName(projectPath) ?? ".", "obj", "project.assets.json");
                 if (!File.Exists(assetsFile))
                 {
@@ -288,11 +290,14 @@ namespace NugetUtility
                     return Array.Empty<string>();
                 }
 
-                return GetProjectReferencesFromAssetsFile(assetsFile);
+                references = GetProjectReferencesFromAssetsFile(assetsFile);
             }
 
-            // First try to get references from new project file format
-            var references = GetProjectReferencesFromNewProjectFile(projectPath);
+            // Then try to get references from new project file format
+            if (!references.Any())
+            {
+                references = GetProjectReferencesFromNewProjectFile(projectPath);
+            }
 
             // Then if needed from old packages.config
             if (!references.Any())

--- a/src/Methods.cs
+++ b/src/Methods.cs
@@ -287,10 +287,11 @@ namespace NugetUtility
                 if (!File.Exists(assetsFile))
                 {
                     WriteOutput(() => $"Cannot find {assetsFile}", logLevel: LogLevel.Warning);
-                    return Array.Empty<string>();
                 }
-
-                references = GetProjectReferencesFromAssetsFile(assetsFile);
+                else
+                {
+                    references = GetProjectReferencesFromAssetsFile(assetsFile);
+                }
             }
 
             // Then try to get references from new project file format

--- a/src/PackageOptions.cs
+++ b/src/PackageOptions.cs
@@ -70,6 +70,9 @@ namespace NugetUtility
         [Option("ignore-ssl-certificate-errors", Default = false, HelpText = "Ignore SSL certificate errors in HttpClient.")]
         public bool IgnoreSslCertificateErrors { get; set; }
 
+        [Option("use-project-assets-json", Default = false, HelpText = "Use the resolved project.assets.json file for each project as the source of package information. Requires the -t option. Requires `nuget restore` or `dotnet restore` to be run first.")]
+        public bool UseProjectAssetsJson { get; set; }
+
         [Usage(ApplicationAlias = "dotnet-project-licenses")]
         public static IEnumerable<Example> Examples
         {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -25,6 +25,14 @@ namespace NugetUtility
                 return 1;
             }
 
+            if (options.UseProjectAssetsJson && !options.IncludeTransitive)
+            {
+                Console.WriteLine("ERROR(S):");
+                Console.WriteLine("--use-project-assets-json\tThis option always includes transitive references, so you must also provide the -t option.");
+
+                return 1;
+            }
+
             try
             {
                 Methods methods = new Methods(options);


### PR DESCRIPTION
This addresses #29 by bypassing csproj file parsing and using the _project.assets.json_ file generated by nuget/dotnet restore.

* Adds `--use-project-assets-json`
* Fails if this is used without `-t` since the assets file includes all transitive refs. There might be a way to parse only immediate refs from the assets file, but I haven't looked into it. This is why I made this as a separate cmd line option rather than making it the default behavior.
* This option bypasses the .csproj parsing if any refs are found in the assets file.
