### PR TITLE
Added --timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Usage: dotnet-project-licenses [options]
 | `--version` | Display version information. |
 | `--ignore-ssl-certificate-errors` | Ignores SSL certificate errors in HttpClient. |
 | `--use-project-assets-json` | Use the resolved project.assets.json file for each project as the source of package information. Requires the `-t` option since this always includes transitive references. Requires `nuget restore` or `dotnet restore` to be run first. |
+| `--timeout` | Set HttpClient timeout in seconds. |
 
 ## Example tool commands
 

--- a/src/Methods.cs
+++ b/src/Methods.cs
@@ -29,7 +29,6 @@ namespace NugetUtility
         private static HttpClient _httpClient;
 
         private const int maxRedirects = 5; // HTTP client max number of redirects allowed
-        private const int timeout = 10; // HTTP client timeout in seconds
         private readonly IReadOnlyDictionary<string, string> _licenseMappings;
         private readonly PackageOptions _packageOptions;
         private readonly XmlSerializer _serializer;
@@ -54,7 +53,7 @@ namespace NugetUtility
                 _httpClient = new HttpClient(httpClientHandler)
                 {
                     BaseAddress = new Uri(nugetUrl),
-                    Timeout = TimeSpan.FromSeconds(timeout)
+                    Timeout = TimeSpan.FromSeconds(packageOptions.Timeout)
                 };
             }
 

--- a/src/PackageOptions.cs
+++ b/src/PackageOptions.cs
@@ -73,6 +73,9 @@ namespace NugetUtility
         [Option("use-project-assets-json", Default = false, HelpText = "Use the resolved project.assets.json file for each project as the source of package information. Requires the -t option. Requires `nuget restore` or `dotnet restore` to be run first.")]
         public bool UseProjectAssetsJson { get; set; }
 
+        [Option("timeout", Default = 10, HelpText = "Set HttpClient timeout in seconds.")]
+        public int Timeout { get; set; }
+
         [Usage(ApplicationAlias = "dotnet-project-licenses")]
         public static IEnumerable<Example> Examples
         {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -33,6 +33,14 @@ namespace NugetUtility
                 return 1;
             }
 
+            if (options.Timeout < 1)
+            {
+                Console.WriteLine("ERROR(S):");
+                Console.WriteLine("--timeout\tThe timeout must be a positive number.");
+
+                return 1;
+            }
+
             try
             {
                 Methods methods = new Methods(options);

--- a/tests/NugetUtility.Tests/MethodsTests.cs
+++ b/tests/NugetUtility.Tests/MethodsTests.cs
@@ -18,7 +18,7 @@ namespace NugetUtility.Tests {
         [SetUp]
         public void Setup () {
             _projectPath = @"../../../";
-            _methods = new Methods (new PackageOptions { ProjectDirectory = _projectPath });
+            _methods = new Methods (new PackageOptions { ProjectDirectory = _projectPath, Timeout = 10 });
         }
 
         private void AddUniquePackageOption () {

--- a/tests/NugetUtility.Tests/ProgramTests.cs
+++ b/tests/NugetUtility.Tests/ProgramTests.cs
@@ -25,6 +25,16 @@ namespace NugetUtility.Tests {
             status.Should ().Be (1);
         }
 
+        [TestCase (0)]
+        [TestCase (-15)]
+        [Test]
+        public async Task Main_Should_Error_With_Invalid_Timeout (int timeout)
+        {
+            var status = await Program.Main($"--timeout {timeout}".Split(' '));
+
+            status.Should().Be(1);
+        }
+
         [TestCase ("-i " + TestSetup.ThisProjectSolutionPath + @" --allowed-license-types ../../../SampleAllowedLicenses.json")]
         [Test]
         public async Task Main_Should_ReturnNegative_When_InvalidLicenses (string args) {


### PR DESCRIPTION
We had issues with slow runners that causes HttpClient timeouts.
By introducing the timeout option, this issue would be solved.