### PR TITLE
Adding Visual Basic Project File (.vbproj) as supported file extension

### DIFF
--- a/src/Methods.cs
+++ b/src/Methods.cs
@@ -251,8 +251,8 @@ namespace NugetUtility
 
         public string[] GetProjectExtensions(bool withWildcard = false) =>
             withWildcard ?
-            new[] { "*.csproj", "*.fsproj" } :
-            new[] { ".csproj", ".fsproj" };
+            new[] { "*.csproj", "*.fsproj", "*.vbproj" } :
+            new[] { ".csproj", ".fsproj", ".vbproj" };
 
         /// <summary>
         /// Retreive the project references from csproj or fsproj file


### PR DESCRIPTION
Adding Visual Basic Project File as supported file extension

Tested and working with own sample .NET Framework project file in VB