### PR TITLE
make .vbproj a valid project

### DIFF
--- a/src/Methods.cs
+++ b/src/Methods.cs
@@ -690,6 +690,9 @@ namespace NugetUtility
                 case ".fsproj":
                     validProjects = new string[] { projectPath };
                     break;
+                case ".vbproj":
+                    validProjects = new string[] { projectPath };
+                    break;
                 case ".json":
                     validProjects = ReadListFromFile<string>(projectPath)
                         .Select(x => x.EnsureCorrectPathCharacter())


### PR DESCRIPTION
Sorry! 😐 Somehow my old PR worked in debug for me but not anymore in stable v2.3.8.
Maybe there can be tests for this in the future, but I have no idea about that.

I missed this part here in GetValidProjects. Now it should work with .vbproj projects.
I will report back if it is working after merge. Merry Christmas 🙂