### PR TITLE
adding --default-proxy flag to use the system proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Usage: dotnet-project-licenses [options]
 | `--ignore-ssl-certificate-errors` | Ignores SSL certificate errors in HttpClient. |
 | `--use-project-assets-json` | Use the resolved project.assets.json file for each project as the source of package information. Requires the `-t` option since this always includes transitive references. Requires `nuget restore` or `dotnet restore` to be run first. |
 | `--timeout` | Set HttpClient timeout in seconds. |
-| `--default-proxy` | Set the default proxy from the system environment in HttpClient. |
+| `--proxy-url` | Set a proxy server URL to be used by HttpClient. |
+| `--proxy-system-auth` | Use the system credentials for proxy authentication. |
 
 ## Example tool commands
 
@@ -102,6 +103,19 @@ dotnet-project-licenses -i projectFolder -o -j -f ~/Projects/github --outfile ~/
 ```ps
 dotnet-project-licenses -i projectFolder --export-license-texts --packages-filter '/Microsoft.*/'
 ```
+
+### Use a proxy server when getting nuget package information via http requests
+
+```ps
+dotnet-project-licenses -i projectFolder --proxy-url "http://my.proxy.com:8080"
+```
+
+### Use a proxy server requiring authentication with the system credentials
+
+```ps
+dotnet-project-licenses -i projectFolder --proxy-url "http://my.proxy.com:8080" --proxy-system-auth
+```
+
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Usage: dotnet-project-licenses [options]
 | `--ignore-ssl-certificate-errors` | Ignores SSL certificate errors in HttpClient. |
 | `--use-project-assets-json` | Use the resolved project.assets.json file for each project as the source of package information. Requires the `-t` option since this always includes transitive references. Requires `nuget restore` or `dotnet restore` to be run first. |
 | `--timeout` | Set HttpClient timeout in seconds. |
+| `--default-proxy` | Set the default proxy from the system environment in HttpClient. |
 
 ## Example tool commands
 

--- a/src/Methods.cs
+++ b/src/Methods.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
@@ -40,6 +41,10 @@ namespace NugetUtility
         {
             if (_httpClient is null)
             {
+                if (packageOptions.DefaultProxy)
+                {
+                    HttpClient.DefaultProxy.Credentials = CredentialCache.DefaultCredentials;
+                }
                 var httpClientHandler = new HttpClientHandler
                 {
                     AllowAutoRedirect = true,

--- a/src/Methods.cs
+++ b/src/Methods.cs
@@ -41,15 +41,22 @@ namespace NugetUtility
         {
             if (_httpClient is null)
             {
-                if (packageOptions.DefaultProxy)
-                {
-                    HttpClient.DefaultProxy.Credentials = CredentialCache.DefaultCredentials;
-                }
                 var httpClientHandler = new HttpClientHandler
                 {
                     AllowAutoRedirect = true,
                     MaxAutomaticRedirections = maxRedirects
                 };
+
+                if (!string.IsNullOrWhiteSpace(packageOptions.ProxyURL))
+                {
+                    var myProxy = new WebProxy(new Uri(packageOptions.ProxyURL));
+                    if (packageOptions.ProxySystemAuth)
+                    {
+                        myProxy.Credentials = CredentialCache.DefaultCredentials;
+                    }
+                    httpClientHandler.Proxy = myProxy;
+                }
+                
                 if (packageOptions.IgnoreSslCertificateErrors)
                 {
                     httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, sslPolicyErrors) => IgnoreSslCertificateErrorCallback(message, cert, chain, sslPolicyErrors);

--- a/src/PackageOptions.cs
+++ b/src/PackageOptions.cs
@@ -76,8 +76,11 @@ namespace NugetUtility
         [Option("timeout", Default = 10, HelpText = "Set HttpClient timeout in seconds.")]
         public int Timeout { get; set; }
 
-        [Option("default-proxy", Default = false, HelpText = "Set the default proxy from the system environment in HttpClient.")]
-        public bool DefaultProxy { get; set; }
+        [Option("proxy-url", HelpText = "Set a proxy server URL to be used by HttpClient.")]
+        public string ProxyURL { get; set; }
+
+        [Option("proxy-system-auth", Default = false, HelpText = "Use the system credentials for proxy authentication.")]
+        public bool ProxySystemAuth { get; set; }
 
         [Usage(ApplicationAlias = "dotnet-project-licenses")]
         public static IEnumerable<Example> Examples

--- a/src/PackageOptions.cs
+++ b/src/PackageOptions.cs
@@ -76,6 +76,9 @@ namespace NugetUtility
         [Option("timeout", Default = 10, HelpText = "Set HttpClient timeout in seconds.")]
         public int Timeout { get; set; }
 
+        [Option("default-proxy", Default = false, HelpText = "Set the default proxy from the system environment in HttpClient.")]
+        public bool DefaultProxy { get; set; }
+
         [Usage(ApplicationAlias = "dotnet-project-licenses")]
         public static IEnumerable<Example> Examples
         {


### PR DESCRIPTION
In order to make API requests successful in working environments with proxy configurations, it is necessary to use the system proxy in HttpClient. 

The flag `--default-proxy` is added. When used, the system proxy is applied for every http request.

Implemented using https://docs.microsoft.com/de-de/dotnet/api/system.net.http.httpclient.defaultproxy