### PR TITLE
Add repository information to JSON output.

### DIFF
--- a/src/Methods.cs
+++ b/src/Methods.cs
@@ -496,7 +496,13 @@ namespace NugetUtility
                     item.Metadata.Description ?? string.Empty,
                 LicenseType = manual?.LicenseType ?? licenseType ?? string.Empty,
                 LicenseUrl = manual?.LicenseUrl ?? licenseUrl ?? string.Empty,
-                Projects = _packageOptions.IncludeProjectFile ? projectFile : null
+                Projects = _packageOptions.IncludeProjectFile ? projectFile : null,
+                Repository = manual?.Repository ?? new LibraryRepositoryInfo
+                {
+                    Url = item.Metadata.Repository?.Url ?? string.Empty,
+                    Commit = item.Metadata.Repository?.Commit ?? string.Empty,
+                    Type = item.Metadata.Repository?.Type ?? string.Empty,
+                }
             };
         }
 

--- a/src/Model/LibraryInfo.cs
+++ b/src/Model/LibraryInfo.cs
@@ -11,5 +11,13 @@ namespace NugetUtility
         public string LicenseUrl { get; set; }
         public string LicenseType { get; set; }
         public string Projects { get; set; }
+        public LibraryRepositoryInfo Repository { get; set; }
+    }
+
+    public class LibraryRepositoryInfo
+    {
+        public string Type { get; set; }
+        public string Url { get; set; }
+        public string Commit { get; set; }
     }
 }


### PR DESCRIPTION
We (our project) need to check the git repositories for licenses that override whatever nuget says. This adds the repository information to the json output format.