### PR TITLE
Add '--convert-html-to-text' option

### DIFF
--- a/src/Methods.cs
+++ b/src/Methods.cs
@@ -1000,6 +1000,41 @@ namespace NugetUtility
             }
         }
 
+        public void ConvertHtmlFileToText(string htmlFile)
+        {
+            var htmlDocument = new HtmlAgilityPack.HtmlDocument();
+            
+            htmlDocument.Load(htmlFile);
+            
+            string htmlStrippedText =
+                System.Web.HttpUtility.HtmlDecode(
+                    htmlDocument.DocumentNode.InnerText
+                );
+            
+            string textFile = htmlFile.Replace(".html", ".txt");
+            
+            WriteOutput(
+                line: $"Converting {htmlFile} to {textFile}...",
+                logLevel: LogLevel.Verbose
+            );    
+            File.WriteAllText(textFile, htmlStrippedText);
+
+            WriteOutput(
+                line: $"Deleting {htmlFile}...",
+                logLevel: LogLevel.Verbose
+            );
+            File.Delete(htmlFile);
+        }
+
+        public void ConvertHtmlFilesToText(string htmlFolder)
+        {
+            var htmlFiles = Directory.GetFiles(htmlFolder, "*.html");
+            foreach (var htmlFile in htmlFiles)
+            {
+                ConvertHtmlFileToText(htmlFile);
+            }
+        }
+
         private bool IsGithub(string uri)
         {
             return uri.StartsWith("https://github.com", StringComparison.Ordinal);

--- a/src/NugetUtility.csproj
+++ b/src/NugetUtility.csproj
@@ -19,6 +19,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommandLineParser" Version="2.8.0" />
+		<PackageReference Include="HtmlAgilityPack" Version="1.11.42" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="NuGet.Versioning" Version="6.1.0" />
 		<PackageReference Include="System.IO.Compression" Version="4.3.0" />

--- a/src/PackageOptions.cs
+++ b/src/PackageOptions.cs
@@ -70,6 +70,9 @@ namespace NugetUtility
         [Option('t', "include-transitive", Default = false, HelpText = "Include distinct transitive package licenses per project file.")]
         public bool IncludeTransitive { get; set; }
 
+        [Option("convert-html-to-text", Default = false, HelpText = "Convert html licenses to plain text.")]
+        public bool ConvertHtmlToText { get; set; }
+
         [Option("ignore-ssl-certificate-errors", Default = false, HelpText = "Ignore SSL certificate errors in HttpClient.")]
         public bool IgnoreSslCertificateErrors { get; set; }
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -25,6 +25,14 @@ namespace NugetUtility
                 return 1;
             }
 
+            if (options.ConvertHtmlToText && !options.ExportLicenseTexts)
+            {
+                Console.WriteLine("ERROR(S):");
+                Console.WriteLine("--convert-html-to-text\tThis option requires the --export-license-texts option.");
+
+                return 1;
+            }
+
             if (options.UseProjectAssetsJson && !options.IncludeTransitive)
             {
                 Console.WriteLine("ERROR(S):");
@@ -51,6 +59,13 @@ namespace NugetUtility
                 if (options.ExportLicenseTexts)
                 {
                     await methods.ExportLicenseTexts(mappedLibraryInfo);
+                }
+
+                if (options.ConvertHtmlToText)
+                {
+                    methods.ConvertHtmlFilesToText(
+                        methods.GetExportDirectory()
+                    );
                 }
 
                 mappedLibraryInfo = methods.HandleDeprecateMSFTLicense(mappedLibraryInfo);


### PR DESCRIPTION
Introduce the '--convert-html-to-text' option, that converts .html
license files (exported using '--export-license-texts') to .txt, by
stripping and decoding HTML.

(Partially?) fix #81.

This is certainly not a perfect implementation, and could see some refactoring
and improvement.

All it really does is get the innerText DOM property and decode HTML entities,
so the formatting of the output text files is sometimes a bit awkward.

That said, at least it gives you an option to get text instead of HTML.
And since in some cases these HTML license files are huge (with CSS and JS
embedded 🤯), I still consider it a step up (i.e. works for my project).


Example excerpt from `System.Resources.ResourceManager_4.0.0.html`:
```
<h1 style='margin-top:6.0pt;margin-right:0in;margin-bottom:0in;margin-left:
.25in;margin-bottom:.0001pt;text-indent:-.25in'><span style='font-size:10.0pt'>1.<span
style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp; </span></span><span
style='font-size:10.0pt'>INSTALLATION AND USE RIGHTS. </span></h1>

<p class=Bullet3 style='margin-top:0in;margin-right:0in;margin-bottom:6.0pt;
margin-left:.25in;text-indent:0in'><span style='font-size:10.0pt'>You may
install and use any number of copies of the software </span><span
style='font-size:10.0pt;color:black'>to develop and test your applications.&nbsp;
</span></p>

<h1><span style='font-size:10.0pt'>2.<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;
</span></span><span style='font-size:10.0pt'>THIRD PARTY COMPONENTS. </span><span
style='font-weight:normal'>The software may include third party components with
separate legal notices or governed by other agreements, as may be described in
the ThirdPartyNotices file(s) </span><span style='font-size:10.0pt;font-weight:
normal'>accompanying the software.</span></h1>
```

Converted to `System.Resources.ResourceManager_4.0.0.txt`:

```
1.    INSTALLATION AND USE RIGHTS. 

You may
install and use any number of copies of the software to develop and test your applications. 


2.   
THIRD PARTY COMPONENTS. The software may include third party components with
separate legal notices or governed by other agreements, as may be described in
the ThirdPartyNotices file(s) accompanying the software.
```

Not perfect, but much more human-readable.