### PR TITLE
specify license in project file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,29 +73,15 @@ jobs:
         with:
           # Filepath of the project to be packaged, relative to root of repository
           PROJECT_FILE_PATH: src/NuGetUtility/NuGetUtility.csproj
+          
+          # Configuration to build and package
+          BUILD_CONFIGURATION: Release
 
           # NuGet package id, used for version detection & defaults to project name
           PACKAGE_NAME: dotnet-project-licenses
 
-          # Filepath with version info, relative to root of repository & defaults to PROJECT_FILE_PATH
-          # VERSION_FILE_PATH: Directory.Build.props
-
           # Regex pattern to extract version info in a capturing group
           VERSION_REGEX: <Version>(.*)<\/Version>
 
-          # Useful with external providers like Nerdbank.GitVersioning, ignores VERSION_FILE_PATH & VERSION_REGEX
-          # VERSION_STATIC: 1.0.0
-
-          # Flag to toggle git tagging, enabled by default
-          # TAG_COMMIT: true
-
-          # Format of the git tag, [*] gets replaced with actual version
-          # TAG_FORMAT: v*
-
           # API key to authenticate with NuGet server
           NUGET_KEY: ${{secrets.NUGET_KEY}}
-
-          # NuGet server uri hosting the packages, defaults to https://api.nuget.org
-          NUGET_SOURCE: https://api.nuget.org
-
-          # Flag to toggle pushing symbo

--- a/src/NuGetUtility/NuGetUtility.csproj
+++ b/src/NuGetUtility/NuGetUtility.csproj
@@ -9,11 +9,12 @@
         <RepositoryType>git</RepositoryType>
         <PackageId>dotnet-project-licenses</PackageId>
         <ToolCommandName>dotnet-project-licenses</ToolCommandName>
-        <Version>3.0.0-alpha.1</Version>
+        <Version>3.0.0-alpha.2</Version>
         <Authors>Tom Chavakis,Simon Ensslen</Authors>
         <Company>-</Company>
         <Title>.NET Core Tool to print a list of the licenses of a projects</Title>
         <PackageProjectUrl>https://github.com/tomchavakis/nuget-license</PackageProjectUrl>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <GeneratePackageOnBuild Condition="'$(GeneratePackageOnBuild)' == ''">false</GeneratePackageOnBuild>
         <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
         <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
This PR specifies the license of the project in the project file. This in turn leads to proper license information to be found about the project.