### PR TITLE
Implement the possibility to specify solution files as input to the application

### DIFF
--- a/src/NuGetUtility/AppLifetime.cs
+++ b/src/NuGetUtility/AppLifetime.cs
@@ -57,4 +57,4 @@
             _doneEvent.Set();
         }
     }
-} 
+}

--- a/src/NuGetUtility/NuGetUtility.csproj
+++ b/src/NuGetUtility/NuGetUtility.csproj
@@ -25,10 +25,10 @@
 
     <ItemGroup>
         <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1"/>
-        <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" Version="17.1.0"/>
+        <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" Version="17.3.1"/>
         <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1"/>
-        <PackageReference Include="NuGet.Commands" Version="6.1.0"/>
-        <PackageReference Include="NuGet.Packaging" Version="6.1.0"/>
+        <PackageReference Include="NuGet.Commands" Version="6.3.0"/>
+        <PackageReference Include="NuGet.Packaging" Version="6.3.0"/>
     </ItemGroup>
 
 </Project>

--- a/src/NuGetUtility/ReferencedPackagesReader/ProjectsCollector.cs
+++ b/src/NuGetUtility/ReferencedPackagesReader/ProjectsCollector.cs
@@ -1,0 +1,20 @@
+﻿using NuGetUtility.Wrapper.MsBuildWrapper;
+
+namespace NuGetUtility.ReferencedPackagesReader
+{
+    public class ProjectsCollector
+    {
+        private readonly IMsBuildAbstraction _msBuild;
+        public ProjectsCollector(IMsBuildAbstraction msBuild)
+        {
+            _msBuild = msBuild;
+        }
+
+        public IEnumerable<string> GetProjects(string inputPath)
+        {
+            return Path.GetExtension(inputPath).Equals(".sln")
+                ? _msBuild.GetProjectsFromSolution(inputPath).Where(File.Exists)
+                : new List<string>(new[] { inputPath });
+        }
+    }
+}

--- a/src/NuGetUtility/Wrapper/MsBuildWrapper/IMsBuildAbstraction.cs
+++ b/src/NuGetUtility/Wrapper/MsBuildWrapper/IMsBuildAbstraction.cs
@@ -4,5 +4,6 @@
     {
         IEnumerable<PackageReference> GetPackageReferencesFromProjectForFramework(IProject project, string framework);
         IProject GetProject(string projectPath);
+        IEnumerable<string> GetProjectsFromSolution(string inputPath);
     }
 }

--- a/src/NuGetUtility/Wrapper/MsBuildWrapper/MsBuildAbstraction.cs
+++ b/src/NuGetUtility/Wrapper/MsBuildWrapper/MsBuildAbstraction.cs
@@ -31,7 +31,9 @@ namespace NuGetUtility.Wrapper.MsBuildWrapper
             return targetOutputs.First(e => e.Key.Equals(CollectPackageReferences))
                 .Value.Items.Select(p =>
                     new PackageReference(p.ItemSpec,
-                        string.IsNullOrEmpty(p.GetMetadata("version")) ? null : new WrappedNuGetVersion(p.GetMetadata("version"))));
+                        string.IsNullOrEmpty(p.GetMetadata("version"))
+                            ? null
+                            : new WrappedNuGetVersion(p.GetMetadata("version"))));
         }
 
         public IProject GetProject(string projectPath)
@@ -48,6 +50,11 @@ namespace NuGetUtility.Wrapper.MsBuildWrapper
             }
 
             return projectWrapper;
+        }
+        public IEnumerable<string> GetProjectsFromSolution(string inputPath)
+        {
+            var sln = SolutionFile.Parse(inputPath);
+            return sln.ProjectsInOrder.Select(p => p.AbsolutePath);
         }
 
         private static void RegisterMsBuildLocatorIfNeeded()

--- a/tests/NuGetUtility.Test/NuGetUtility.Test.csproj
+++ b/tests/NuGetUtility.Test/NuGetUtility.Test.csproj
@@ -16,8 +16,8 @@
         <PackageReference Include="AutoFixture" Version="4.17.0"/>
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0"/>
         <PackageReference Include="AutoFixture.NUnit3" Version="4.17.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
-        <PackageReference Include="Moq" Version="4.17.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1"/>
+        <PackageReference Include="Moq" Version="4.18.2"/>
         <PackageReference Include="NUnit" Version="3.13.3"/>
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1"/>
         <PackageReference Include="coverlet.collector" Version="3.1.2">

--- a/tests/NuGetUtility.Test/ReferencedPackagesReader/ProjectsCollectorTest.cs
+++ b/tests/NuGetUtility.Test/ReferencedPackagesReader/ProjectsCollectorTest.cs
@@ -1,0 +1,115 @@
+﻿using AutoFixture;
+using Moq;
+using NuGetUtility.ReferencedPackagesReader;
+using NuGetUtility.Test.Helper.ShuffelledEnumerable;
+using NuGetUtility.Wrapper.MsBuildWrapper;
+using NUnit.Framework;
+
+namespace NuGetUtility.Test.ReferencedPackagesReader
+{
+    [TestFixture]
+    public class ProjectsCollectorTest
+    {
+
+        [SetUp]
+        public void SetUp()
+        {
+            _fixture = new Fixture();
+            _msBuild = new Mock<IMsBuildAbstraction>();
+            _uut = new ProjectsCollector(_msBuild.Object);
+        }
+        private Mock<IMsBuildAbstraction> _msBuild = null!;
+        private ProjectsCollector _uut = null!;
+        private Fixture _fixture = null!;
+
+        [TestCase("A.csproj")]
+        [TestCase("B.fsproj")]
+        [TestCase("C.vbproj")]
+        [TestCase("D.dbproj")]
+        public void GetProjects_Should_ReturnProjectsAsListDirectly(string projectFile)
+        {
+            var result = _uut.GetProjects(projectFile);
+            CollectionAssert.AreEqual(new[] { projectFile }, result);
+            _msBuild.Verify(m => m.GetProjectsFromSolution(It.IsAny<string>()), Times.Never);
+        }
+
+        [TestCase("A.sln")]
+        [TestCase("B.sln")]
+        [TestCase("C.sln")]
+        public void GetProjects_Should_QueryMsBuildToGetProjectsForSolutionFiles(string solutionFile)
+        {
+            _ = _uut.GetProjects(solutionFile);
+
+            _msBuild.Verify(m => m.GetProjectsFromSolution(solutionFile), Times.Once);
+        }
+
+        [TestCase("A.sln")]
+        [TestCase("B.sln")]
+        [TestCase("C.sln")]
+        public void GetProjects_Should_ReturnEmptyArray_If_SolutionContainsNoProjects(string solutionFile)
+        {
+            _msBuild.Setup(m => m.GetProjectsFromSolution(It.IsAny<string>())).Returns(Enumerable.Empty<string>());
+
+            var result = _uut.GetProjects(solutionFile);
+            CollectionAssert.AreEqual(new string[] { }, result);
+
+            _msBuild.Verify(m => m.GetProjectsFromSolution(solutionFile), Times.Once);
+        }
+
+        [TestCase("A.sln")]
+        [TestCase("B.sln")]
+        [TestCase("C.sln")]
+        public void GetProjects_Should_ReturnEmptyArray_If_SolutionContainsProjectsThatDontExist(string solutionFile)
+        {
+            var projects = _fixture.CreateMany<string>();
+            _msBuild.Setup(m => m.GetProjectsFromSolution(It.IsAny<string>())).Returns(projects);
+
+            var result = _uut.GetProjects(solutionFile);
+            CollectionAssert.AreEqual(new string[] { }, result);
+
+            _msBuild.Verify(m => m.GetProjectsFromSolution(solutionFile), Times.Once);
+        }
+
+        [TestCase("A.sln")]
+        [TestCase("B.sln")]
+        [TestCase("C.sln")]
+        public void GetProjects_Should_ReturnArrayOfProjects_If_SolutionContainsProjectsThatDoExist(string solutionFile)
+        {
+            var projects = _fixture.CreateMany<string>().ToArray();
+            CreateFiles(projects);
+            _msBuild.Setup(m => m.GetProjectsFromSolution(It.IsAny<string>())).Returns(projects);
+
+            var result = _uut.GetProjects(solutionFile);
+            CollectionAssert.AreEqual(projects, result);
+
+            _msBuild.Verify(m => m.GetProjectsFromSolution(solutionFile), Times.Once);
+        }
+
+        [TestCase("A.sln")]
+        [TestCase("B.sln")]
+        [TestCase("C.sln")]
+        public void GetProjects_Should_ReturnOnlyExistingProjectsInSolutionFile(string solutionFile)
+        {
+            var existingProjects = _fixture.CreateMany<string>().ToArray();
+            var missingProjects = _fixture.CreateMany<string>();
+
+            CreateFiles(existingProjects);
+
+            _msBuild.Setup(m => m.GetProjectsFromSolution(It.IsAny<string>()))
+                .Returns(existingProjects.Concat(missingProjects).Shuffle());
+
+            var result = _uut.GetProjects(solutionFile);
+            CollectionAssert.AreEquivalent(existingProjects, result);
+
+            _msBuild.Verify(m => m.GetProjectsFromSolution(solutionFile), Times.Once);
+        }
+
+        private void CreateFiles(IEnumerable<string> files)
+        {
+            foreach (var file in files)
+            {
+                File.WriteAllBytes(file, Array.Empty<byte>());
+            }
+        }
+    }
+}

--- a/tests/NuGetUtility.Test/ReferencedPackagesReader/ReferencedPackagesReaderIntegrationTest.cs
+++ b/tests/NuGetUtility.Test/ReferencedPackagesReader/ReferencedPackagesReaderIntegrationTest.cs
@@ -49,11 +49,10 @@ namespace NuGetUtility.Test.ReferencedPackagesReader
 
             var result = _uut!.GetInstalledPackages(path, true).ToArray();
 
-            Assert.That(result.Count, Is.EqualTo(4));
+            Assert.That(result.Count, Is.EqualTo(3));
             var titles = result.Select(metadata => metadata.Title).ToArray();
             Assert.That(titles.Contains("Moq"), Is.True);
             Assert.That(titles.Contains("Castle.Core"), Is.True);
-            Assert.That(titles.Contains("System.Threading.Tasks.Extensions"), Is.True);
             Assert.That(titles.Contains("System.Diagnostics.EventLog"), Is.True);
         }
 

--- a/tests/targets/ProjectWithTransitiveNuget/ProjectWithTransitiveNuget.csproj
+++ b/tests/targets/ProjectWithTransitiveNuget/ProjectWithTransitiveNuget.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Moq" Version="4.18.1"/>
+        <PackageReference Include="Moq" Version="4.18.2"/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds the capability to specify a solution file as input to the version 3.0.0 of the application. Further this PR alos allows for the input json file to contain solution files, project files or a combination of these.