### PR TITLE
add first architecture test to codify architecture rules

### DIFF
--- a/tests/NuGetUtility.Test/Architecture/ArchitectureTest.cs
+++ b/tests/NuGetUtility.Test/Architecture/ArchitectureTest.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using NetArchTest.Rules;
+
+namespace NuGetUtility.Test.Architecture
+{
+    public abstract class ArchitectureTest
+    {
+        protected Types Types { get; }
+
+        protected ArchitectureTest()
+        {
+            this.Types = Types.InAssemblies(new[] { Assembly.Load(AssemblyNames.NuGetUtility) });
+        }
+
+        internal static class AssemblyNames
+        {
+            internal const string NuGetUtility = "NugetUtility";
+        }
+    }
+}

--- a/tests/NuGetUtility.Test/Architecture/ConditionsExtensions.cs
+++ b/tests/NuGetUtility.Test/Architecture/ConditionsExtensions.cs
@@ -1,0 +1,14 @@
+using NetArchTest.Rules;
+
+namespace NuGetUtility.Test.Architecture
+{
+    internal static class ConditionsExtensions
+    {
+        public static void Assert(this ConditionList conditions, string message = "Architecture rule broken.")
+        {
+            var ruleResult = conditions.GetResult();
+            var failingTypeNames = string.Join(Environment.NewLine, ruleResult.FailingTypeNames ?? Array.Empty<string>());
+            NUnit.Framework.Assert.True(ruleResult.IsSuccessful, $"{message}{Environment.NewLine}Offending types:{Environment.NewLine}{failingTypeNames}");
+        }
+    }
+}

--- a/tests/NuGetUtility.Test/Architecture/Rules/NugetAbstractionTest.cs
+++ b/tests/NuGetUtility.Test/Architecture/Rules/NugetAbstractionTest.cs
@@ -1,0 +1,19 @@
+
+
+namespace NuGetUtility.Test.Architecture.Rules
+{
+    public class NugetAbstractionTest : ArchitectureTest
+    {
+        public NugetAbstractionTest() : base() {}
+
+        [Test]
+        public void TestOnlyNugetWrapperHasDependencyToNuget()
+        {
+            this.Types.That()
+                .DoNotResideInNamespace($"{AssemblyNames.NuGetUtility}.{nameof(Wrapper)}.{nameof(Wrapper.NuGetWrapper)}")
+                .And().DoNotResideInNamespace($"{AssemblyNames.NuGetUtility}.{nameof(Program)}")
+                .ShouldNot().HaveDependencyOn(nameof(NuGet))
+                .Assert($"Only the {nameof(Wrapper.NuGetWrapper)} should have dependencies to {nameof(NuGet)}.");
+        }
+    }
+}

--- a/tests/NuGetUtility.Test/NuGetUtility.Test.csproj
+++ b/tests/NuGetUtility.Test/NuGetUtility.Test.csproj
@@ -19,6 +19,7 @@
         <PackageReference Include="Bogus" Version="34.0.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="Moq" Version="4.18.2" />
+        <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
         <PackageReference Include="coverlet.collector" Version="3.2.0">


### PR DESCRIPTION
As suggested in [this comment](https://github.com/tomchavakis/nuget-license/pull/154#issuecomment-1311504630), here's a simple example of an architecture test.