### PR TITLE
Fix getting from global folder

### DIFF
--- a/src/NuGetUtility/Wrapper/NuGetWrapper/Protocol/GlobalPackagesFolderUtility.cs
+++ b/src/NuGetUtility/Wrapper/NuGetWrapper/Protocol/GlobalPackagesFolderUtility.cs
@@ -29,7 +29,7 @@ namespace NuGetUtility.Wrapper.NuGetWrapper.Protocol
             using PackageReaderBase pkgStream = cachedPackage.PackageReader;
             var manifest = Manifest.ReadFrom(pkgStream.GetNuspec(), true);
 
-            if (manifest.Metadata.Version.ToString() != identity.Version.ToString())
+            if (manifest.Metadata.Version.Equals(identity.Version))
             {
                 return null;
             }


### PR DESCRIPTION
This is broken in alpha because SemanticVersion.ToString and WrappedNuGetVersion.ToString behaves differently when there revision part is zero, version x.x.x.0.