### PR TITLE
Update Dockerfile to .net 7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
 WORKDIR /src
 
 
@@ -7,10 +7,10 @@ RUN dotnet restore
 
 
 COPY . ./
-RUN dotnet publish -f net5.0 -c Release -o out
+RUN dotnet publish -f net7.0 -c Release -o out
 
 
-FROM mcr.microsoft.com/dotnet/runtime:5.0
+FROM mcr.microsoft.com/dotnet/runtime:7.0
 WORKDIR /src
 COPY --from=build-env /src/out .
 ENTRYPOINT ["dotnet", "NugetUtility.dll"]


### PR DESCRIPTION
When following the README instructions to build the Docker image locally, I was getting the following error:

```Dockerfile
 > [build-env 4/6] RUN dotnet restore:
#11 1.265   Determining projects to restore...
#11 1.694 /usr/share/dotnet/sdk/5.0.408/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(141,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 6.0.  Either target .NET 5.0 or lower, or use a version of the .NET SDK that supports .NET 6.0. [/src/NugetUtility.csproj]
------
executor failed running [/bin/sh -c dotnet restore]: exit code: 1
```

I confirm that the image builds and runs correctly in this version which makes sense as the code supports 7.0 as per https://github.com/tomchavakis/nuget-license/pull/177

