### PR TITLE
Fixed issue when package version is range, e.g. [6.2.*,)

### DIFF
--- a/src/Methods.cs
+++ b/src/Methods.cs
@@ -292,7 +292,7 @@ namespace NugetUtility
             try
             {
                 VersionRange vRange = VersionRange.Parse(versionRange);
-                return vRange.FindBestMatch(versionList).ToString();
+                return vRange.FindBestMatch(versionList)?.ToString() ?? "";
             }
             catch (NullReferenceException)
             {
@@ -348,7 +348,7 @@ namespace NugetUtility
                 var references = this.GetProjectReferences(projectFile);
                 var referencedPackages = references.Select((package) =>
                 {
-                    var split = package.Split(',');
+                    var split = package.Split(',', 2);
                     return new PackageNameAndVersion { Name = split[0], Version = split[1] };
                 });
                 WriteOutput(Environment.NewLine + "Project:" + projectFile + Environment.NewLine, logLevel: LogLevel.Information);

--- a/tests/NugetUtility.Tests/TestProjectFiles/PackageRangeReference.csproj
+++ b/tests/NugetUtility.Tests/TestProjectFiles/PackageRangeReference.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="[6.2.*,)" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixed issue when package version is range, e.g. [6.2.*,) . Also, fixd NullReferenceException issue when packages doesn't exists in local cache.