### PR TITLE
Add option to exclude non referenced manual packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Usage: dotnet-project-licenses [options]
   <tr><td> -p, --print </td><td>(Default: true) Print licenses</td></tr>
   <tr><td> -e, --export-license-texts </td><td>Export the raw license texts</td></tr>
   <tr><td> -c, --convert-html-to-text </td><td>Strip HTML tags if the license file is HTML and save as plain text (EXPERIMENTAL)</td></tr>
+  <tr><td> --exclude-non-referenced-manual-packages</td><td>(Default: false) Exclude non-referenced manual packages from detected package list. Only applicable when using <code>--manual-package-information</code>.</td></tr>
   <tr><td> --help </td><td>Display this help screen</td></tr>
   <tr><td> --version </td><td>Display version information</td></tr>
   <tr><td> --ignore-ssl-certificate-errors </td><td>Ignore SSL certificate errors in HttpClient</td></tr>

--- a/src/PackageOptions.cs
+++ b/src/PackageOptions.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text.RegularExpressions;
+
 using CommandLine;
 using CommandLine.Text;
+
 using static NugetUtility.Utilities;
 
 namespace NugetUtility
@@ -22,7 +24,7 @@ namespace NugetUtility
 
         [Option("allowed-license-types", Default = null, HelpText = "Simple json file of a text array of allowable licenses, if no file is given, all are assumed allowed. Cannot be used alongside 'forbidden-license-types'.")]
         public string AllowedLicenseTypesOption { get; set; }
-        
+
         [Option("forbidden-license-types", Default = null, HelpText = "Simple json file of a text array of forbidden licenses, if no file is given, none are assumed forbidden. Cannot be used alongside 'allowed-license-types'.")]
         public string ForbiddenLicenseTypesOption { get; set; }
 
@@ -94,6 +96,9 @@ namespace NugetUtility
 
         [Option('w', "page-width", Default = 80, HelpText = "The page width, in characters, to use for HTML to text conversion.")]
         public int PageWidth { get; set; }
+
+        [Option("exclude-non-referenced-manual-packages-from-output", Default = false, HelpText = "Exclude non-referenced manual packages from output.")]
+        public bool ExcludeNonReferencedManualPackagesFromOutput { get; set; }
 
         [Usage(ApplicationAlias = "dotnet-project-licenses")]
         public static IEnumerable<Example> Examples

--- a/src/PackageOptions.cs
+++ b/src/PackageOptions.cs
@@ -97,7 +97,7 @@ namespace NugetUtility
         [Option('w', "page-width", Default = 80, HelpText = "The page width, in characters, to use for HTML to text conversion.")]
         public int PageWidth { get; set; }
 
-        [Option("exclude-non-referenced-manual-packages-from-output", Default = false, HelpText = "Exclude non-referenced manual packages from output.")]
+        [Option("exclude-non-referenced-manual-packages", Default = false, HelpText = "Exclude non-referenced manual packages.")]
         public bool ExcludeNonReferencedManualPackagesFromOutput { get; set; }
 
         [Usage(ApplicationAlias = "dotnet-project-licenses")]

--- a/tests/NugetUtility.Tests/ProgramTests.cs
+++ b/tests/NugetUtility.Tests/ProgramTests.cs
@@ -2,105 +2,132 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading.Tasks;
+
 using FluentAssertions;
+
 using NUnit.Framework;
 
-namespace NugetUtility.Tests {
+namespace NugetUtility.Tests
+{
     [ExcludeFromCodeCoverage]
     [TestFixture]
-    public class ProgramTests {
-        [TestCase ("-bad val")]
-        [TestCase ("-i good -bad val")]
+    public class ProgramTests
+    {
+        [TestCase("-bad val")]
+        [TestCase("-i good -bad val")]
         [Test]
-        public async Task Main_Should_Error_With_Invalid_Args (string args) {
-            var status = await Program.Main (args.Split (' '));
+        public async Task Main_Should_Error_With_Invalid_Args(string args)
+        {
+            var status = await Program.Main(args.Split(' '));
 
-            status.Should ().Be (1);
+            status.Should().Be(1);
         }
 
         [Test]
-        public async Task Main_Should_Error_Empty_Input () {
-            var status = await Program.Main ("-j".Split (' '));
+        public async Task Main_Should_Error_Empty_Input()
+        {
+            var status = await Program.Main("-j".Split(' '));
 
-            status.Should ().Be (1);
+            status.Should().Be(1);
         }
 
-        [TestCase (0)]
-        [TestCase (-15)]
+        [TestCase(0)]
+        [TestCase(-15)]
         [Test]
-        public async Task Main_Should_Error_With_Invalid_Timeout (int timeout)
+        public async Task Main_Should_Error_With_Invalid_Timeout(int timeout)
         {
             var status = await Program.Main($"--timeout {timeout}".Split(' '));
 
             status.Should().Be(1);
         }
 
-        [TestCase ("-i " + TestSetup.ThisProjectSolutionPath + @" --allowed-license-types ../../../SampleAllowedLicenses.json")]
+        [TestCase("-i " + TestSetup.ThisProjectSolutionPath + @" --allowed-license-types ../../../SampleAllowedLicenses.json")]
         [Test]
-        public async Task Main_Should_ReturnNegative_When_InvalidLicenses (string args) {
-            var status = await Program.Main (args.Split (' '));
+        public async Task Main_Should_ReturnNegative_When_InvalidLicenses(string args)
+        {
+            var status = await Program.Main(args.Split(' '));
 
-            status.Should ().Be (-1);
+            status.Should().Be(-1);
         }
 
         [Test]
-        public async Task Main_Should_Run_For_This_Project () {
-            var status = await Program.Main (@"-i ../../../".Split (' '));
+        public async Task Main_Should_Run_For_This_Project()
+        {
+            var status = await Program.Main(@"-i ../../../".Split(' '));
 
-            status.Should ().Be (0);
+            status.Should().Be(0);
         }
 
         [Test]
-        public async Task Main_Should_Run_For_This_Solution_With_Custom_Outfile () {
+        public async Task Main_Should_Run_For_This_Solution_With_Custom_Outfile()
+        {
             const string args = "-i " + TestSetup.ThisProjectSolutionPath + " -j --outfile custom.json";
-            var status = await Program.Main (args.Split (' '));
+            var status = await Program.Main(args.Split(' '));
 
-            status.Should ().Be (0);
-            File.Exists ("custom.json").Should ().BeTrue ();
+            status.Should().Be(0);
+            File.Exists("custom.json").Should().BeTrue();
         }
 
         [Test]
-        public async Task Main_Should_Run_For_This_Solution_With_Custom_Directory () {
+        public async Task Main_Should_Run_For_This_Solution_With_Custom_Directory()
+        {
             const string args = "-i " + TestSetup.ThisProjectSolutionPath + " -f /tmp -j --outfile custom.json";
-            var status = await Program.Main (args.Split (' '));
+            var status = await Program.Main(args.Split(' '));
 
-            status.Should ().Be (0);
-            File.Exists ("/tmp/custom.json").Should ().BeTrue ();
+            status.Should().Be(0);
+            File.Exists("/tmp/custom.json").Should().BeTrue();
         }
 
         [Test]
-        public async Task Main_Should_Run_For_This_Solution_With_ManualInformation () {
+        public async Task Main_Should_Run_For_This_Solution_With_ManualInformation()
+        {
             const string args = "-i " + TestSetup.ThisProjectSolutionPath + @" -j --outfile custom-manual.json --manual-package-information ../../../SampleManualInformation.json";
-            var status = await Program.Main (args.Split (' '));
+            var status = await Program.Main(args.Split(' '));
 
-            status.Should ().Be (0);
-            var outputFile = new FileInfo ("custom-manual.json");
-            outputFile.Exists.Should ().BeTrue ();;
-            Utilities.ReadListFromFile<LibraryInfo> (outputFile.FullName)
-                .Should ().Contain (l => l.PackageName == "ASamplePackage");
+            status.Should().Be(0);
+            var outputFile = new FileInfo("custom-manual.json");
+            outputFile.Exists.Should().BeTrue(); ;
+            Utilities.ReadListFromFile<LibraryInfo>(outputFile.FullName)
+                .Should().Contain(l => l.PackageName == "ASamplePackage");
         }
 
         [Test]
-        public async Task Main_Should_ReturnOne_When_AllowedLicenses_Is_Passed_With_ForbiddenLicenses() {
-            var args = "--allowed-license-types ../../../SampleAllowedLicenses.json --forbidden-license-types ../../../SampleForbiddenLicenses.json";
-            var status = await Program.Main (args.Split (' '));
+        public async Task Main_Should_Run_For_This_Solution_With_ManualInformation_And_NonReferencedManualInformationExcluded()
+        {
+            const string args = "-i " + TestSetup.ThisProjectSolutionPath + @" -j --outfile custom-manual.json --manual-package-information ../../../SampleManualInformation.json --exclude-non-referenced-manual-packages";
+            var status = await Program.Main(args.Split(' '));
 
-            status.Should ().Be(1);
+            status.Should().Be(0);
+            var outputFile = new FileInfo("custom-manual.json");
+            outputFile.Exists.Should().BeTrue();
+            Utilities.ReadListFromFile<LibraryInfo>(outputFile.FullName)
+                .Should().NotContain(l => l.PackageName == "ASamplePackage");
+        }
+
+        [Test]
+        public async Task Main_Should_ReturnOne_When_AllowedLicenses_Is_Passed_With_ForbiddenLicenses()
+        {
+            var args = "--allowed-license-types ../../../SampleAllowedLicenses.json --forbidden-license-types ../../../SampleForbiddenLicenses.json";
+            var status = await Program.Main(args.Split(' '));
+
+            status.Should().Be(1);
         }
 
 #if WINDOWS
         [Test]
-        public async Task Main_Should_Run_For_This_Solution_With_Custom_Outfile_FullPath () {
+        public async Task Main_Should_Run_For_This_Solution_With_Custom_Outfile_FullPath()
+        {
             const string args = "-i " + TestSetup.ThisProjectSolutionPath + @" -j --outfile c:\temp\custom.json";
-            var tempDirectory = new DirectoryInfo (@"C:\temp");
-            if (!tempDirectory.Exists) {
-                tempDirectory.Create ();
+            var tempDirectory = new DirectoryInfo(@"C:\temp");
+            if (!tempDirectory.Exists)
+            {
+                tempDirectory.Create();
             }
-            var status = await Program.Main (args.Split (' '));
+            var status = await Program.Main(args.Split(' '));
 
-            status.Should ().Be (0);
-            File.Exists (@"c:\temp\custom.json").Should ().BeTrue ();
-            File.Delete (@"c:\temp\custom.json");
+            status.Should().Be(0);
+            File.Exists(@"c:\temp\custom.json").Should().BeTrue();
+            File.Delete(@"c:\temp\custom.json");
         }
 #endif
     }


### PR DESCRIPTION
First of all I want to thank you for this great tool! The tool has been really convenient for use in CI/CD pipelines to allow only specific licenses and to report the list of used packages in markdown format.

In the current implementation all non-referenced packages that exist in the manual package information are included in the list of detected packages. I'm using this tool in CI/DI pipelines with a shared manual.json. In our pipelines we use the manual json to fix packages for which no license info could be retrieved automatically. This works great but also adds all the manual packages to the list of detected packages; even when the packages are not referenced at all. In my PR I added an option to exclude non referenced manual packages.

Let me know what you think.
Thanks in advance.